### PR TITLE
Rad.yaml build clarifications

### DIFF
--- a/docs/content/reference/rad-yaml.md
+++ b/docs/content/reference/rad-yaml.md
@@ -41,8 +41,7 @@ Build defines a list of builds to run prior to a deployment. However, note that 
 | Platform | Description | Example |
 |----------|-------------|---------|
 | Local | The container registry is overridden with the local registry that Radius creates for you. | `radius-dev-registry` |
-| Microsoft Azure | Your build should contain the name of the container registry that correlates to your Azure resource group. For more information visit the [Radius Azure Platform]({{< ref azure.md >}}) page.  | `<YOUR AZURE ACCOUNT>.azurecr.io/go-service` |
-| Kubernetes | The container registry must be configured for your Kubernetes cluster, and you are in charge of setting up those configurations. | `<YOUR CONTAINER REGISTRY>/go-service` |
+| Microsoft Azure/Kubernetes | Your build should contain the name of the container registry that correlates to your Azure resource group or Kubernetes cluster. | `<YOUR CONTAINER REGISTRY>/go-service` |
 
 #### Docker
 

--- a/docs/content/reference/rad-yaml.md
+++ b/docs/content/reference/rad-yaml.md
@@ -36,7 +36,13 @@ Bicep defines a Bicep file and optional parameters to deploy to a Radius environ
 
 ### Build
 
-Build defines a list of builds to run prior to a deployment.
+Build defines a list of builds to run prior to a deployment. However, note that there are different behaviors for each type of Radius environments.
+
+| Platform | Description | Example |
+|----------|-------------|---------|
+| Local | The container registry is overridden with the local registry that Radius creates for you. | `radius-dev-registry` |
+| Microsoft Azure | Your build should contain the name of the container registry that correlates to your Azure resource group. For more information visit the [Radius Azure Platform]({{< ref azure.md >}}) page.  | `<YOUR AZURE ACCOUNT>.azurecr.io/go-service` |
+| Kubernetes | The container registry must be configured for your Kubernetes cluster, and you are in charge of setting up those configurations. | `<YOUR CONTAINER REGISTRY>/go-service` |
 
 #### Docker
 

--- a/docs/content/reference/rad-yaml.md
+++ b/docs/content/reference/rad-yaml.md
@@ -36,6 +36,8 @@ Bicep defines a Bicep file and optional parameters to deploy to a Radius environ
 
 ### Build
 
+Build defines a list of builds to run prior to a deployment.
+
 #### Docker
 
 Docker defines a Docker build to run prior to a deployment.

--- a/docs/content/reference/rad-yaml.md
+++ b/docs/content/reference/rad-yaml.md
@@ -36,13 +36,6 @@ Bicep defines a Bicep file and optional parameters to deploy to a Radius environ
 
 ### Build
 
-Build defines a list of builds to run prior to a deployment. However, note that there are different behaviors for each type of Radius environments.
-
-| Platform | Description | Example |
-|----------|-------------|---------|
-| Local | The container registry is overridden with the local registry that Radius creates for you. | `radius-dev-registry` |
-| Microsoft Azure/Kubernetes | Your build should contain the name of the container registry that correlates to your Azure resource group or Kubernetes cluster. | `<YOUR CONTAINER REGISTRY>/go-service` |
-
 #### Docker
 
 Docker defines a Docker build to run prior to a deployment.
@@ -50,7 +43,7 @@ Docker defines a Docker build to run prior to a deployment.
 | Property | Description | Example |
 |----------|-------------|---------|
 | context | The directory to run the Docker build in. | `serviceA` |
-| image | The name of the Docker image to build. | `myregistry/myimage` |
+| image | The name/tag of the Docker image to build and push at deploy time. When running locally with [`rad app run`]({{< ref rad_application_run >}}) this value is overriden to use the [local registry]({{< ref "local#local-container-registry" >}}). | `myregistry/myimage` |
 | dockerfile | The name of the Dockerfile to use. | `Dockerfile` |
 
 ### Profiles

--- a/docs/content/user-guides/samples/container-app-store/3-cas-services/index.md
+++ b/docs/content/user-guides/samples/container-app-store/3-cas-services/index.md
@@ -13,80 +13,30 @@ As part of a Radius deployment, the container images are built and provided to t
 
 Open [`rad.yaml`]({{< ref rad-yaml >}}) to see where the containers are built:
 
-{{< tabs "Local Environment" "Azure/Kubernetes Environment" >}}
-
-{{% codetab %}}
-
-For local environments, the `Build` section of your `rad.yaml` does not need to point to any specific image, Radius automatically overwrites whatever your input is to the container registry created when your local environment is initialized.
+{{% alert title="Local container registry" color="info" %}}
+When deployed, the Docker images are built and pushed to the registries specified within `build.docker.image`. When running locally with [`rad app run`]({{< ref rad_application_run >}}), the containers are instead built and pushed to the [local container registry]({{< ref "local#local-container-registry" >}}).
+{{% /alert %}}
 
 ```yaml
 name: store
 stages:
-- name: infra
-  bicep:
-    template: iac/infra.bicep
-  profiles:
-    dev:
-      bicep:
-        template: iac/infra.dev.bicep
+...
 - name: app
   build:
     go_service_build:
       docker:
         context: go-service
-        # Ignored
-        image: MYREGISTRY/go-service
+        image: MYREGISTRY/go-service # Overriden to local container registry when run locally
     node_service_build:
       docker:
         context: node-service
-        # Ignored
-        image: MYREGISTRY/node-service
+        image: MYREGISTRY/node-service # Overriden to local container registry when run locally
     python_service_build:
       docker:
         context: python-service
-        # Ignored
-        image: MYREGISTRY/python
+        image: MYREGISTRY/python # Overriden to local container registry when run locally
   ...
 ```
-
-{{% /codetab %}}
-
-{{% codetab %}}
-For other environments, make sure that the `image` value is corresponding to the container registry that is registered with either the Azure resource group you're connected to or your Kubernetes cluster.
-
-```yaml
-name: store
-stages:
-- name: infra
-  bicep:
-    template: iac/infra.bicep
-  profiles:
-    dev:
-      bicep:
-        template: iac/infra.dev.bicep
-- name: app
-  build:
-    go_service_build:
-      docker:
-        context: go-service
-        # Container Registry
-        image: <MYREGISTRY>/go-service
-    node_service_build:
-      docker:
-        context: node-service
-        # Container Registry
-        image: <MYREGISTRY>/node-service
-    python_service_build:
-      docker:
-        context: python-service
-        # Container Registry
-        image: <MYREGISTRY>/python
-  ...
-```
-
-{{% /codetab %}}
-
-{{< /tabs >}}
 
 Within `app.bicep`, object parameters with the same name as the build steps are available to use with the container image imformation from the above step:
 

--- a/docs/content/user-guides/samples/container-app-store/3-cas-services/index.md
+++ b/docs/content/user-guides/samples/container-app-store/3-cas-services/index.md
@@ -13,6 +13,12 @@ As part of a Radius deployment, the container images are built and provided to t
 
 Open [`rad.yaml`]({{< ref rad-yaml >}}) to see where the containers are built:
 
+{{< tabs "Local Environment" "Azure Environment" "Kubernetes Environment)" >}}
+
+{{% codetab %}}
+
+For local environments, the `Build` section of your `rad.yaml` does not need to point to any specific image, Radius automatically overwrites whatever your input is to the container registry created when your local environment is initialized.
+
 ```yaml
 name: store
 stages:
@@ -28,17 +34,96 @@ stages:
     go_service_build:
       docker:
         context: go-service
+        # Ignored
         image: MYREGISTRY/go-service
     node_service_build:
       docker:
         context: node-service
+        # Ignored
         image: MYREGISTRY/node-service
     python_service_build:
       docker:
         context: python-service
+        # Ignored
         image: MYREGISTRY/python
   ...
 ```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+For Azure environments, make sure that the `image` value is corresponding to the container registry that is registered with the Azure resource group you're connected to.
+
+```yaml
+name: store
+stages:
+- name: infra
+  bicep:
+    template: iac/infra.bicep
+  profiles:
+    dev:
+      bicep:
+        template: iac/infra.dev.bicep
+- name: app
+  build:
+    go_service_build:
+      docker:
+        context: go-service
+        # Azure Container Registry
+        image: MYREGISTRY.azurecr.io/go-service
+    node_service_build:
+      docker:
+        context: node-service
+        # Azure Container Registry
+        image: MYREGISTRY.azurecr.io/node-service
+    python_service_build:
+      docker:
+        context: python-service
+        # Azure Container Registry
+        image: MYREGISTRY.azurecr.io/python
+  ...
+```
+
+{{% /codetab %}}
+
+{{% codetab %}}
+
+For Kubernetes environments, you can use any container registry that is configured for your cluster. You just have to make sure that your Kubernetes cluster has access to it.
+
+```yaml
+name: store
+stages:
+- name: infra
+  bicep:
+    template: iac/infra.bicep
+  profiles:
+    dev:
+      bicep:
+        template: iac/infra.dev.bicep
+- name: app
+  build:
+    go_service_build:
+      docker:
+        context: go-service
+        # Kubernetes Container Registry
+        image: MYREGISTRY/go-service
+    node_service_build:
+      docker:
+        context: node-service
+        # Kubernetes Container Registry
+        image: MYREGISTRY/node-service
+    python_service_build:
+      docker:
+        context: python-service
+        # Kubernetes Container Registry
+        image: MYREGISTRY/python
+  ...
+```
+
+{{% /codetab %}}
+
+{{< /tabs >}}
+
 
 Within `app.bicep`, object parameters with the same name as the build steps are available to use with the container image imformation from the above step:
 

--- a/docs/content/user-guides/samples/container-app-store/3-cas-services/index.md
+++ b/docs/content/user-guides/samples/container-app-store/3-cas-services/index.md
@@ -13,7 +13,7 @@ As part of a Radius deployment, the container images are built and provided to t
 
 Open [`rad.yaml`]({{< ref rad-yaml >}}) to see where the containers are built:
 
-{{< tabs "Local Environment" "Azure Environment" "Kubernetes Environment)" >}}
+{{< tabs "Local Environment" "Azure/Kubernetes Environment" >}}
 
 {{% codetab %}}
 
@@ -52,7 +52,7 @@ stages:
 {{% /codetab %}}
 
 {{% codetab %}}
-For Azure environments, make sure that the `image` value is corresponding to the container registry that is registered with the Azure resource group you're connected to.
+For other environments, make sure that the `image` value is corresponding to the container registry that is registered with either the Azure resource group you're connected to or your Kubernetes cluster.
 
 ```yaml
 name: store
@@ -69,61 +69,24 @@ stages:
     go_service_build:
       docker:
         context: go-service
-        # Azure Container Registry
-        image: MYREGISTRY.azurecr.io/go-service
+        # Container Registry
+        image: <MYREGISTRY>/go-service
     node_service_build:
       docker:
         context: node-service
-        # Azure Container Registry
-        image: MYREGISTRY.azurecr.io/node-service
+        # Container Registry
+        image: <MYREGISTRY>/node-service
     python_service_build:
       docker:
         context: python-service
-        # Azure Container Registry
-        image: MYREGISTRY.azurecr.io/python
-  ...
-```
-
-{{% /codetab %}}
-
-{{% codetab %}}
-
-For Kubernetes environments, you can use any container registry that is configured for your cluster. You just have to make sure that your Kubernetes cluster has access to it.
-
-```yaml
-name: store
-stages:
-- name: infra
-  bicep:
-    template: iac/infra.bicep
-  profiles:
-    dev:
-      bicep:
-        template: iac/infra.dev.bicep
-- name: app
-  build:
-    go_service_build:
-      docker:
-        context: go-service
-        # Kubernetes Container Registry
-        image: MYREGISTRY/go-service
-    node_service_build:
-      docker:
-        context: node-service
-        # Kubernetes Container Registry
-        image: MYREGISTRY/node-service
-    python_service_build:
-      docker:
-        context: python-service
-        # Kubernetes Container Registry
-        image: MYREGISTRY/python
+        # Container Registry
+        image: <MYREGISTRY>/python
   ...
 ```
 
 {{% /codetab %}}
 
 {{< /tabs >}}
-
 
 Within `app.bicep`, object parameters with the same name as the build steps are available to use with the container image imformation from the above step:
 

--- a/docs/content/user-guides/samples/container-app-store/5-cas-deploy/index.md
+++ b/docs/content/user-guides/samples/container-app-store/5-cas-deploy/index.md
@@ -1,15 +1,16 @@
 ---
 type: docs
-title: "Deploy Container App Store Microservice application to an environment"
+title: "Deploy Container App Store Microservice application"
 linkTitle: "Deploy app"
 slug: "deploy"
 description: "Learn how to deploy the Container App Store Microservice application to a Radius environment"
 weight: 500
 ---
 
-## Initialize environment
+## Initialize Azure environment
 
 Create a new Azure environment, specifying your subscription and resource group:
+
 ```sh
 rad env init azure -i
 ```
@@ -24,8 +25,12 @@ rad app deploy
 
 The deployed resources, along with gateway IP address, will be output to the console upon a successful deployment.
 
+{{% alert title="Container registry" color="warning" %}}
+Make sure to update the `docker.image` values within your `rad.yaml` file with a container registry that you are able to push to. By default this is set to `MYREGISTRY`, which will throw an error when you try to deploy.
+{{% /alert %}}
+
 ## Visit Container App Store Microservice
 
 Now that Container App Store Microservice is deployed, you can visit the application via the IP address output above.
 
-<img src="container-app-store-microservice.png" alt="Screenshot of the Container App Store Microservice application" width=800 >
+<img src="container-app-store-microservice.png" alt="Screenshot of the Container App Store Microservice application" width=600 >

--- a/docs/content/user-guides/samples/container-app-store/_index.md
+++ b/docs/content/user-guides/samples/container-app-store/_index.md
@@ -3,7 +3,7 @@ type: docs
 title: "Container App Store Microservice sample"
 linkTitle: "Container App Store"
 description: "Learn how to model and deploy multiple microservices with Radius and Dapr"
-weight: 300
+weight: 400
 ---
 
 {{% alert title="Preview" color="warning" %}}


### PR DESCRIPTION
## Description
`rad.yaml` was missing some clarifications in regards to how the `build` parameter operates in different environments. Updated the `rad.yaml` page as well as the Container Apps sample service page to emphasize to users how they should setup that section based on environments.

## Issue
Closes https://github.com/project-radius/radius/issues/2111 