### PR TITLE
Add conditional check for edge docs

### DIFF
--- a/docs/assets/scss/_code.scss
+++ b/docs/assets/scss/_code.scss
@@ -50,6 +50,8 @@
         margin-bottom: 2rem;
 
         max-width: 100%;
+
+        border: none;
 	    
         pre {
             margin: 0;

--- a/docs/assets/scss/_content.scss
+++ b/docs/assets/scss/_content.scss
@@ -1,0 +1,91 @@
+//
+// Style Markdown content
+//
+
+.td-content {
+    order: 1;
+
+    p, li, td {
+        font-weight: $font-weight-body-text;
+    }
+
+    > h1 {
+        font-weight: $font-weight-bold;
+        margin-bottom: 1rem;
+    }
+
+    > h2 {
+        margin-bottom: 1rem;
+    }
+
+    > h2:not(:first-child) {
+        margin-top: 3rem;
+    }
+
+    > h2 + h3 {
+         margin-top: 1rem;
+    }
+
+    > h3, > h4, > h5, > h6 {
+        margin-bottom: 1rem;
+        margin-top: 2rem;
+    }
+
+    h2:after {
+        content:' ';
+        display:block;
+        border:1px solid #000000;
+        border-radius:4px;
+        margin-top: .5rem;
+        background-color: #000000;
+    }
+
+    img {
+        @extend .img-fluid;
+    }
+
+    > table {
+        @extend .table-striped;
+
+        @extend .table-responsive;
+
+        @extend .table;
+    }
+
+    > blockquote {
+        padding: 0 0 0 1rem;
+        margin-bottom: $spacer;
+        color: $gray-600;
+        border-left: 6px solid $secondary;
+    }
+
+    > ul li, > ol li {
+        margin-bottom: .25rem;
+    }
+
+    strong {
+        font-weight: $font-weight-bold;
+    }
+
+    > pre, > .highlight, > .lead, > h1, > h2, > ul, > ol, > p, > blockquote, > dl dd, .footnotes, > .alert {
+        @extend .td-max-width-on-larger-screens;
+    }
+
+    .alert:not(:first-child) {
+        margin-top: 2 * $spacer;
+        margin-bottom: 2 * $spacer;
+    }
+
+    .lead {
+        margin-bottom: 1.5rem;
+    }
+}
+
+.td-title {
+    margin-top: 1rem;
+    margin-bottom: .5rem;
+
+    @include media-breakpoint-up(sm) {
+        font-size: 3rem;
+    }
+}

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -19,10 +19,10 @@ Radius applications and tooling are agnostic of platform, services, and infrastr
 <table style="max-width:600px;margin-top:10%">
   <tr>
     <td style="width:50%;text-align:center">
-      <a href="{{< ref azure-environments >}}"><img src="platforms/azure-logo.png" alt="Azure logo" style="width:80%"></a>
+      <a href="{{< ref azure-environments >}}"><img src="operations/platforms/azure-logo.png" alt="Azure logo" style="width:80%"></a>
     </td>
     <td style="width:50%;text-align:center">
-      <a href="{{< ref kubernetes-environments >}}"><img src="platforms/kubernetes-logo.svg" alt="Kubernetes logo" style="width:80%"></a>
+      <a href="{{< ref kubernetes-environments >}}"><img src="operations/platforms/kubernetes-logo.svg" alt="Kubernetes logo" style="width:80%"></a>
     </td>
   </tr>
 </table>

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -7,7 +7,6 @@ weight: 20
 no_list: true
 ---
 
-
 ## Install `rad` CLI
 
 The `rad` CLI manages your applications, resources, and environments. Begin by installing it on your machine:
@@ -20,11 +19,13 @@ The `rad` CLI manages your applications, resources, and environments. Begin by i
 iwr -useb "https://get.radapp.dev/tools/rad/install.ps1" | iex
 ```
 
+{{< edge >}}
 To install the latest edge version:
 
 ```powershell
 $script=iwr -useb  https://radiuspublic.blob.core.windows.net/tools/rad/install.ps1; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList edge
 ```
+{{< /edge >}}
 {{% /codetab %}}
 
 {{% codetab %}}
@@ -32,11 +33,13 @@ $script=iwr -useb  https://radiuspublic.blob.core.windows.net/tools/rad/install.
 curl -fsSL "https://get.radapp.dev/tools/rad/install.sh" | /bin/bash
 ```
 
+{{< edge >}}
 To install the latest edge version:
 
 ```bash
 curl -fsSL "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /bin/bash -s edge
 ```
+{{< /edge >}}
 {{% /codetab %}}
 
 {{% codetab %}}
@@ -44,11 +47,13 @@ curl -fsSL "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" | /
 wget -q "https://get.radapp.dev/tools/rad/install.sh" -O - | /bin/bash
 ```
 
+{{< edge >}}
 To install the latest edge version:
 
 ```bash
 wget -q "https://radiuspublic.blob.core.windows.net/tools/rad/install.sh" -O - | /bin/bash -s edge
 ```
+{{< /edge >}}
 {{% /codetab %}}
 
 {{% codetab %}}
@@ -75,12 +80,13 @@ PowerShell for Cloud Shell is currently not supported.
 
 1. Ensure the user has permission to execute the binary and place it somewhere on your PATH so it can be invoked easily.
 
+{{< edge >}}
 ### Edge releases
 
 - MacOS: https://radiuspublic.blob.core.windows.net/tools/rad/edge/macos-x64/rad
 - Linux: https://radiuspublic.blob.core.windows.net/tools/rad/edge/linux-x64/rad
 - Windows: https://radiuspublic.blob.core.windows.net/tools/rad/edge/windows-x64/rad.exe
-
+{{< /edge >}}
 {{% /codetab %}}
 
 {{< /tabs >}}

--- a/docs/layouts/shortcodes/edge.html
+++ b/docs/layouts/shortcodes/edge.html
@@ -1,0 +1,8 @@
+{{ $version := $.Page.Site.Params.version }}
+{{ $content := .Inner }}
+
+{{ if eq $version "edge" }}
+{{ $content }}
+{{ else }}
+To try out an unstable release visit the [edge docs](https://edge.radapp.dev).
+{{ end }}


### PR DESCRIPTION
Adds a new shortcode that will only render edge-specific docs when the global version is set to edge.