### PR TITLE
Hide commands that we're de-emphasizing with v0.12

### DIFF
--- a/docs/content/author-apps/_index.md
+++ b/docs/content/author-apps/_index.md
@@ -4,4 +4,6 @@ title: "Developer guides"
 linkTitle: "Developer guides"
 description: "Learn about authoring Radius apps"
 weight: 30
+toc_hide: false
+hide_summary: true
 ---

--- a/docs/content/author-apps/inner-loop/app-run/_index.md
+++ b/docs/content/author-apps/inner-loop/app-run/_index.md
@@ -4,6 +4,8 @@ title: "Run apps locally"
 linkTitle: "Run apps locally"
 description: "How to run a Radius application locally"
 weight: 300
+toc_hide: false
+hide_summary: true
 ---
 
 This guide will get you up and running with a local Radius environment and sample application.
@@ -16,7 +18,7 @@ This guide will get you up and running with a local Radius environment and sampl
 
 ## Initialize a local environment
 
-Begin by initializing a local environment with the [`rad env init dev` command]({{< ref rad_env_init_dev >}}):
+Begin by initializing a local environment with the `rad env init dev` command:
 
 ```sh
 > rad env init dev

--- a/docs/content/author-apps/inner-loop/app-run/_index.md
+++ b/docs/content/author-apps/inner-loop/app-run/_index.md
@@ -36,7 +36,7 @@ Ready (2/2)  localhost:62285  http://localhost:62287  https://localhost:62288
 
 ## Initialize an application
 
-Create a new Radius application with the [`rad app init` command]({{< ref rad_application_init >}}):
+Create a new Radius application with the `rad app init` command:
 
 ```sh
 > rad app init -a myapp
@@ -51,7 +51,7 @@ Have a RAD time 😎
 
 ## Run your application
 
-Run your app locally with the [`rad app run` command]({{< ref rad_application_run >}}):
+Run your app locally with the `rad app run` command:
 
 ```sh
 rad app run

--- a/docs/content/author-apps/inner-loop/dev-environments/_index.md
+++ b/docs/content/author-apps/inner-loop/dev-environments/_index.md
@@ -50,7 +50,7 @@ This will initialize a local Kubernetes cluster within Docker, along with a loca
 
 ### Run applications in the local environment
 
-Once you have a local environment, you can run Radius applications in it with the [`rad app run` command]({{< ref rad_application_run >}}):
+Once you have a local environment, you can run Radius applications in it with the `rad app run` command:
 
 ```sh
 rad app run

--- a/docs/content/author-apps/inner-loop/dev-environments/_index.md
+++ b/docs/content/author-apps/inner-loop/dev-environments/_index.md
@@ -4,6 +4,8 @@ title: "Radius local dev environments"
 linkTitle: "Local environments"
 description: "Run Radius applications locally on your machine"
 weight: 100
+toc_hide: false
+hide_summary: true
 ---
 
 ## Overview
@@ -16,7 +18,7 @@ With a Radius local environment you can run your applications on your machine wi
 
 A Radius local environment automatically creates a local Kubernetes cluster for you on top of Docker, making it easy to get up and running with an application runtime. This removes the need to manually setup and maintain a Kubernetes cluster.
 
-Use [`rad env init dev`]({{< ref rad_env_init_dev>}}) to create an environment.
+Use `rad env init dev` to create an environment.
 
 ### Local container registry
 
@@ -40,7 +42,7 @@ If you configure the optional [Azure provider]({{< ref providers >}}) you can in
 
 ### Create a local dev environment
 
-You can easily get up and running with a local environment with the [`rad env init dev` command]({{< ref rad_env_init_dev >}}):
+You can easily get up and running with a local environment with the `rad env init dev` command:
 
 ```sh
 rad env init dev

--- a/docs/content/getting-started/quickstarts/container-app-store/3-cas-services/index.md
+++ b/docs/content/getting-started/quickstarts/container-app-store/3-cas-services/index.md
@@ -14,7 +14,7 @@ As part of a Radius deployment, the container images are built and provided to t
 Open rad.yaml to see where the containers are built:
 
 {{% alert title="Local container registry" color="info" %}}
-When deployed, the Docker images are built and pushed to the registries specified within `build.docker.image`. When running locally with [`rad app run`]({{< ref rad_application_run >}}), the containers are instead built and pushed to the [local container registry]({{< ref "dev-environments#local-container-registry" >}}).
+When deployed, the Docker images are built and pushed to the registries specified within `build.docker.image`. When running locally with `rad app run`, the containers are instead built and pushed to the [local container registry]({{< ref "dev-environments#local-container-registry" >}}).
 {{% /alert %}}
 
 ```yaml

--- a/docs/content/getting-started/quickstarts/container-app-store/4-cas-run/index.md
+++ b/docs/content/getting-started/quickstarts/container-app-store/4-cas-run/index.md
@@ -42,7 +42,7 @@ Begin by create a new Radius [local dev environment]({{< ref dev-environments >}
 
 ## Run application locally
 
-Using the [`rad app run`]({{< ref rad_application_run >}}) command, run the Container App Store Microservice application in your local environment. This will build the Docker containers, push them to the local registry, and deploy them to the local k3d cluster.
+Using the `rad app run` command, run the Container App Store Microservice application in your local environment. This will build the Docker containers, push them to the local registry, and deploy them to the local k3d cluster.
 
 ```sh
 rad app run app --profile dev  

--- a/docs/content/getting-started/quickstarts/container-app-store/5-cas-deploy/index.md
+++ b/docs/content/getting-started/quickstarts/container-app-store/5-cas-deploy/index.md
@@ -6,32 +6,6 @@ slug: "deploy"
 description: "Learn how to deploy the Container App Store Microservice application to a Radius environment"
 weight: 500
 ---
-
-## Initialize Azure environment
-
-Create a new Azure environment, specifying your subscription and resource group:
-
-```sh
-rad env init azure -i
-```
-<!-- TODO: update to 'rad env init kubernetes' in this whole sample app -->
-
-## Deploy application to Azure
-
-Using the [`rad app deploy`]({{< ref rad_application_deploy >}}) command, deploy the Container App Store Microservice application to your environment:
-
-```sh
-rad app deploy
-```
-
-The deployed resources, along with gateway IP address, will be output to the console upon a successful deployment.
-
-{{% alert title="Container registry" color="warning" %}}
-Make sure to update the `docker.image` values within your `rad.yaml` file with a container registry that you are able to push to. By default this is set to `MYREGISTRY`, which will throw an error when you try to deploy.
-{{% /alert %}}
-
-## Visit Container App Store Microservice
-
-Now that Container App Store Microservice is deployed, you can visit the application via the IP address output above.
-
-<img src="container-app-store-microservice.png" alt="Screenshot of the Container App Store Microservice application" width=600 >
+ 
+ <!-- Jason is working on revamping this app into a sample app instead, and this page will go away anyways. 
+ https://github.com/project-radius/docs/issues/101 -->

--- a/docs/content/getting-started/reference-apps/eshop/4-deploy/index.md
+++ b/docs/content/getting-started/reference-apps/eshop/4-deploy/index.md
@@ -59,7 +59,9 @@ Radius gateways are still in development, and will get more features in upcoming
 
 ## Deploy application
 
-Using the [`rad app deploy`]({{< ref rad_application_deploy >}}) command, deploy the eShop application to your environment:
+<!-- TODO: switch from rad app deploy to rad deploy for v0.12 
+https://github.com/project-radius/docs/issues/178 -->
+Using the `rad app deploy` command, deploy the eShop application to your environment:
 
 {{< tabs Containerized Azure >}}
 {{% codetab %}}


### PR DESCRIPTION
downstream docs changes related to 
https://github.com/project-radius/radius/pull/2922/files

This change hides all of the rad.yaml commands and rad env init dev.