### PR TITLE
VS Code doc scrub and reformat

### DIFF
--- a/docs/content/author-apps/vscode/_index.md
+++ b/docs/content/author-apps/vscode/_index.md
@@ -4,6 +4,8 @@ title: "Visual Studio Code extension"
 linkTitle: "Visual Studio Code"
 description: "Overview of the Project Radius Visual Studio Code extension"
 weight: 300
+toc_hide: true
+hide_summary: true
 ---
 
 Developers can use the *preview* Radius Visual Studio Code extension which offers a variety of features to help manage Radius applications across cloud and edge.

--- a/docs/content/concepts/overview/_index.md
+++ b/docs/content/concepts/overview/_index.md
@@ -81,7 +81,7 @@ The Radius app model is designed to be portable across all Radius-supported plat
 
 ### Consistent tooling
 
-As teams onboard to Project Radius and begin deploying across platforms, the tooling and experiences are consistent everywhere. The [rad CLI]({{< ref cli >}}) and [Radius VS Code extension]({{< ref vscode >}}) work across every platform and environment. This allows teams to easily scale across platforms and be productive everywhere.
+As teams onboard to Project Radius and begin deploying across platforms, the tooling and experiences are consistent everywhere. The [rad CLI]({{< ref cli >}}) works across every platform and environment. This allows teams to easily scale across platforms and be productive everywhere.
 
 ## Next step
 

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -118,10 +118,10 @@ rad env init kubernetes
 
 ## Install VS Code extension (optional)
 
-Optionally install the Radius [Visual Studio Code](https://code.visualstudio.com/) extensions for syntax highlighting, auto-completion, and linting.
+Optionally install the Radius Bicep [Visual Studio Code](https://code.visualstudio.com/) extension for syntax highlighting, auto-completion, and linting.
 
 {{% alert title="Note" color="primary" %}}
-While Project Radius is in preview two separate extensions are required, one for Bicep highlighting and one for interacting with Radius applications. In a future release, these will be combined into a single extension.
+While Project Radius is in preview we offer an extension for Bicep highlighting.
 {{% /alert %}}
 
 1. Download the latest extensions
@@ -131,27 +131,30 @@ While Project Radius is in preview two separate extensions are required, one for
    {{% codetab %}}
    {{< button link="https://get.radapp.dev/tools/vscode-extensibility/stable/rad-vscode-bicep.vsix" text="Download Bicep extension" >}}
 
-   {{< button link="https://radiuspublic.blob.core.windows.net/tools/vscode/stable/rad-vscode.vsix" text="Download Radius extension" >}}
-
    {{< edge >}}
    {{< button link="https://radiuspublic.blob.core.windows.net/tools/vscode-extensibility/edge/rad-vscode-bicep.vsix" text="Download Bicep extension (edge)" >}}
-
-   {{< button link="https://radiuspublic.blob.core.windows.net/tools/vscode/edge/rad-vscode.vsix" text="Download Radius extension (edge)" >}}
    {{< /edge >}}
    {{% /codetab %}}
 
    {{% codetab %}}
 
+   Stable Version
+
    ```bash
    curl https://radiuspublic.blob.core.windows.net/tools/vscode/stable/rad-vscode-bicep.vsix --output rad-vscode-bicep.vsix
-   curl https://radiuspublic.blob.core.windows.net/tools/vscode/stable/rad-vscode.vsix --output rad-vscode.vsix
+   ```
+
+   Edge Version
+
+   ```bash
+   curl https://radiuspublic.blob.core.windows.net/tools/vscode-extensibility/edge/rad-vscode-bicep.vsix --output rad-vscode-bicep.vsix
    ```
 
    {{% /codetab %}}
 
    {{< /tabs >}}
 
-2. Install the `.vsix` files:
+2. Install the `.vsix` file:
 
    {{< tabs UI Terminal >}}
 

--- a/docs/content/getting-started/quickstarts/dapr-quickstart/_index.md
+++ b/docs/content/getting-started/quickstarts/dapr-quickstart/_index.md
@@ -33,7 +33,7 @@ In this tutorial, you will:
   - [kubectl CLI](https://kubernetes.io/docs/tasks/tools/) for local and Kubernetes environments
   
 - [Install Visual Studio Code](https://code.visualstudio.com/) (recommended)
-  - The [Radius VSCode extension]({{< ref "getting-started#setup-vscode" >}}) provides syntax highlighting, completion, and linting.
+  - The [Radius Bicep VSCode extension]({{< ref "getting-started#setup-vscode" >}}) provides syntax highlighting, completion, and linting.
   - You can also complete this tutorial with any basic text editor.
 
 ### Initialize a Radius environment

--- a/docs/content/getting-started/quickstarts/dapr-quickstart/dapr-microservices-initial-deployment/index.md
+++ b/docs/content/getting-started/quickstarts/dapr-quickstart/dapr-microservices-initial-deployment/index.md
@@ -75,23 +75,6 @@ Now you are ready to deploy the application for the first time.
 
 1. When you are done testing press `CTRL+C` to terminate the port-forward.
 
-## Interact with your application using the VS Code extension
-
-{{% alert title="Preview" color="info" %}}
-The following tips are a preview of how the VS Code Radius extension can be used to improve the developer workflow. As we introduce additional features to the extension, we will incorporate them into this section.
-{{% /alert %}}
-
-- Open VS Code and navigate to the VS Code Radius extension explorer section.
-
-   The environment you've created should be listed in a tree view that will allow you to see
-   your dapr-tutorial application.
-
-   <img src="radius-explorer-dapr-microservices.png" width="400" alt="screenshot of the todo application with no database">
-
-   _Note: The resources shown include the resources for UI and Dapr which you will add in the next sections._
-
-- Click on the a resource node and click on the `Show Container Logs` to open up a terminal dedicated to viewing the resource logs.
-
 ## Next step
 
 <br>{{< button text="Next: Add a Dapr to the app" page="dapr-microservices-add-dapr" >}}

--- a/docs/content/getting-started/tutorial/_index.md
+++ b/docs/content/getting-started/tutorial/_index.md
@@ -34,7 +34,7 @@ This tutorial contains the following sections:
   - [K3s](https://k3s.io), a lightweight single-binary certified Kubernetes distribution from Rancher.
   - Another Kubernetes provider of your choice.
 - [Install Visual Studio Code](https://code.visualstudio.com/) (recommended)
-  - The [Radius VSCode extension]({{< ref "getting-started#install-vs-code-extension-optional" >}}) provides syntax highlighting, completion, and linting.
+  - The [Radius Bicep VSCode extension]({{< ref "getting-started#install-vs-code-extension-optional" >}}) provides syntax highlighting, completion, and linting.
   - You can also complete this tutorial with any basic text editor.
 
 <br>{{< button text="Next step: App overview" page="webapp-overview" >}}

--- a/docs/content/getting-started/tutorial/webapp-initial-deployment/index.md
+++ b/docs/content/getting-started/tutorial/webapp-initial-deployment/index.md
@@ -86,16 +86,4 @@ You can play around with the application's features:
 - Mark a todo item as complete
 - Delete a todo item
 
-## Manage your application using the Radius VS Code extension
-
-The Radius extension improves developer workflows. 
-
-- In VS Code, select the "PR" (Project Radius) icon on the left to view the Radius extension.
-
-   Environments you've created are listed in a tree view. By drilling into your "todoapp" application and its resources.
-
-   <img src="radius-explorer-webapp.png" width="400" height="auto" alt="screenshot of the todo application with no database">
-
-- Click on the `todoapp` resource node and click on the `Show Container Logs` to open view its logs.
-
 <br> {{< button text="Previous step: Initialize an environment" page="webapp-initialize-environment" newline="false" >}}{{< button text="Next step: Add a database connector" page="webapp-add-database" >}} 


### PR DESCRIPTION
## Description
Hide the vscode section and removed vscode extension references as well as reformatted small parts with the Bicep extension.

## Solves

Issues: radius-project/core-team#552 , radius-project/radius#195 , https://github.com/project-radius/radius/issues/3090