### PR TITLE
Update KinD cluster instruction

### DIFF
--- a/docs/content/operations/platforms/kubernetes/_index.md
+++ b/docs/content/operations/platforms/kubernetes/_index.md
@@ -40,7 +40,9 @@ rad env init kubernetes -i --public-endpoint-override 'http://localhost:8081'
 {{% codetab %}}
 [Kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters inside Docker containers. Use the following setup to create a new cluster and install the Radius control plane, along with a new environment:
 
-First, copy the text below into a new file `kind-config.yaml`:
+First, ensure that memory resource is 4GB or more in `Resource` setting of `Preferences` if you're using Docker Desktop.
+
+Second, copy the text below into a new file `kind-config.yaml`:
 ```yaml
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
## Summary

WebApp tutorial requires more memory to deploy database such as mongo db. This PR is to add the instruction to increase the memory resource for Docker Desktop users. 

## Related issue

https://github.com/project-radius/radius/issues/3311
