### PR TITLE
add k3s memory requirement

### DIFF
--- a/docs/content/operations/platforms/kubernetes/_index.md
+++ b/docs/content/operations/platforms/kubernetes/_index.md
@@ -29,7 +29,11 @@ rad env init kubernetes -i
 {{% /codetab %}}
 
 {{% codetab %}}
-[k3d](https://k3d.io) is a lightweight wrapper to run [k3s](https://github.com/rancher/k3s) (Rancher Lab’s minimal Kubernetes distribution) in Docker. Use the following commands to create a new cluster and install the Radius control plane, along with a new environment:
+[k3d](https://k3d.io) is a lightweight wrapper to run [k3s](https://github.com/rancher/k3s) (Rancher Lab’s minimal Kubernetes distribution) in Docker. 
+
+First, ensure that memory resource is 4GB or more in `Resource` setting of `Preferences` if you're using Docker Desktop.
+
+Next, use the following commands to create a new cluster and install the Radius control plane, along with a new environment:
 
 ```bash
 k3d cluster create -p "8081:80@loadbalancer" --k3s-arg "--disable=traefik@server:0"


### PR DESCRIPTION
@youngbupark helped me troubleshoot issues today where I was running into networking errors like 
`Error: pollingTrackerBase#pollForStatus: failed to send HTTP request: StatusCode=0 -- Original Error: http2: client connection lost`
when my Docker Desktop memory was set to 2GB.

using the same verbiage as we use for kind clusters. 