### PR TITLE
Update limitations for redis connectionString()

### DIFF
--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -94,7 +94,7 @@ results in a Dapr component named 'myapp-statestore'.
 
 In order to consume this Dapr resource from a container, either use the environment variable injected into the container (`CONNECTION_STATESTORE_NAME`), or manually craft an environment variable with `'${app.name}-${statestore.name}'`.
 
-### `connectionString()` method fails to return value for Redis setup with Azure Cache
+### `connectionString()` method returns empty value for RedisCache Connector setup with Azure Redis Cache
 
 If a Redis connector is setup with an Azure Cache for Redis resource, the `connectionString()` method will fail to return a value.
 

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -98,7 +98,7 @@ In order to consume this Dapr resource from a container, either use the environm
 
 If a Redis connector is setup with an Azure Cache for Redis resource, the `connectionString()` method will fail to return a value.
 
-As a workaround, manually configure the `secrets.connectionString` property in the connector, using values for `host` and `port` that you will get from the Azure Cache.
+As a workaround, manually configure the connector from values, using the `hostName`, `port`, and key that you will get from the Azure Cache for Redis.
 
 For example, for an Azure Cache called `redis`, you can create a connector using the following:
 

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -94,6 +94,31 @@ results in a Dapr component named 'myapp-statestore'.
 
 In order to consume this Dapr resource from a container, either use the environment variable injected into the container (`CONNECTION_STATESTORE_NAME`), or manually craft an environment variable with `'${app.name}-${statestore.name}'`.
 
+### `connectionString()` method fails to return value for Redis setup with Azure Cache
+
+If a Redis connector is setup with an Azure Cache for Redis resource, the `connectionString()` method will fail to return a value.
+
+As a workaround, manually configure the `secrets.connectionString` property in the connector, using values for `host` and `port` that you will get from the Azure Cache.
+
+For example, for an Azure Cache called `redis`, you can create a connector using the following:
+
+```bicep
+resource redisConnector 'Applications.Connector/redisCaches@2022-03-15-privatepreview' = {
+  name: 'redis-connector'
+  location: location
+  properties: {
+    application: app.id
+    environment: environment
+    host: redis.properties.hostName
+    port: redis.properties.sslPort
+    secrets: {
+      password: redis.listKeys().primaryKey
+      connectionString: '${redis.properties.hostName}:${redis.properties.sslPort},password=${redis.listKeys().primaryKey},ssl=True,abortConnect=False'
+    }
+  }
+}
+```
+
 ## Connections
 
 ### Direct connections to Azure resources with IAM roles are not supported

--- a/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
+++ b/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
@@ -56,7 +56,7 @@ The following methods are available on the Redis connector:
 | connectionString() | Get the connection string for the Redis cache. |
 | password() | Get the password for the Redis cache. |
 
-NOTE: Currently, the `connectionString()` method is not supported for Redis connectors created using the `resource` property. As a workaround, the `connectionString` secret can be manually set and accessed using this method.
+NOTE: Currently, the `connectionString()` method is not supported for Redis connectors created using the `resource` property. As a workaround, the `connectionString` secret can be manually set and then accessed.  See our [known limitations page]({{< ref limitations >}}) for more information.
 
 ## Supported resources
 

--- a/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
+++ b/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
@@ -44,6 +44,7 @@ The `redislabs.com/Redis` connector is a [portable connector]({{< ref connectors
 
 | Property | Required | Description | Example(s) |
 |----------|:--------:|-------------|------------|
+| connectionString | n | The connection string for the Redis cache. Write only. | `https://mycache.redis.cache.windows.net,password=*****,....`
 | password | n | The password for the Redis cache. Write only. | `mypassword`
 
 ## Methods
@@ -54,6 +55,8 @@ The following methods are available on the Redis connector:
 |--------|-------------|
 | connectionString() | Get the connection string for the Redis cache. |
 | password() | Get the password for the Redis cache. |
+
+NOTE: Currently, the `connectionString()` method is not supported for Redis connectors created using the `resource` property. As a workaround, the `connectionString` secret can be manually set and accessed using this method.
 
 ## Supported resources
 

--- a/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
+++ b/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
@@ -44,7 +44,6 @@ The `redislabs.com/Redis` connector is a [portable connector]({{< ref connectors
 
 | Property | Required | Description | Example(s) |
 |----------|:--------:|-------------|------------|
-| connectionString | n | The connection string for the Redis cache. Write only. | `https://mycache.redis.cache.windows.net,password=*****,....`
 | password | n | The password for the Redis cache. Write only. | `mypassword`
 
 ## Methods


### PR DESCRIPTION
Update docs to include current limitations for getting the connection string of a redis connector using the `connectionString()` method. Tracking this bug in [#3352](https://github.com/project-radius/radius/issues/3352).