### PR TITLE
Remove limitations for Redis connection string with Azure

### DIFF
--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -94,31 +94,6 @@ results in a Dapr component named 'myapp-statestore'.
 
 In order to consume this Dapr resource from a container, either use the environment variable injected into the container (`CONNECTION_STATESTORE_NAME`), or manually craft an environment variable with `'${app.name}-${statestore.name}'`.
 
-### `connectionString()` method returns empty value for RedisCache Connector setup with Azure Redis Cache
-
-If a Redis connector is setup with an Azure Cache for Redis resource, the `connectionString()` method will fail to return a value.
-
-As a workaround, manually configure the connector from values, using the `hostName`, `port`, and key that you will get from the Azure Cache for Redis.
-
-For example, for an Azure Cache called `redis`, you can create a connector using the following:
-
-```bicep
-resource redisConnector 'Applications.Connector/redisCaches@2022-03-15-privatepreview' = {
-  name: 'redis-connector'
-  location: 'global'
-  properties: {
-    application: app.id
-    environment: environment
-    host: redis.properties.hostName
-    port: redis.properties.sslPort
-    secrets: {
-      password: redis.listKeys().primaryKey
-      connectionString: '${redis.properties.hostName}:${redis.properties.sslPort},password=${redis.listKeys().primaryKey},ssl=True,abortConnect=False'
-    }
-  }
-}
-```
-
 ## Connections
 
 ### Direct connections to Azure resources with IAM roles are not supported

--- a/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
+++ b/docs/content/reference/resource-schema/connector-schema/cache/redis/index.md
@@ -56,8 +56,6 @@ The following methods are available on the Redis connector:
 | connectionString() | Get the connection string for the Redis cache. |
 | password() | Get the password for the Redis cache. |
 
-NOTE: Currently, the `connectionString()` method is not supported for Redis connectors created using the `resource` property. As a workaround, the `connectionString` secret can be manually set and then accessed.  See our [known limitations page]({{< ref limitations >}}) for more information.
-
 ## Supported resources
 
 The following resources are supported when building the connector from a resource using the `resource` property:


### PR DESCRIPTION
Removing limitations for connection string for redis connector with Azure resource now that https://github.com/project-radius/radius/issues/3352 is implemented.

Related issue: https://github.com/project-radius/docs/issues/295