### PR TITLE
Adding workaround for `rad env init kubernetes` on EKS

### DIFF
--- a/docs/content/getting-started/tutorial/1-tutorial-environment/index.md
+++ b/docs/content/getting-started/tutorial/1-tutorial-environment/index.md
@@ -27,13 +27,14 @@ A Radius [Kubernetes environment]({{<ref environments-concept>}}) can run in a K
 
 In this step we will be initializing a Radius Kubernetes environment.
 
-> Visit the [Kubernetes platform docs]({{< ref kubernetes >}}) for a list of supported clusters and specific cluster requirements.
-
 1. You can view the current context for kubectl by running:
 
    ```bash
    kubectl config current-context
    ```
+
+   {{% alert color="success" %}} Visit the [Kubernetes platform docs]({{< ref kubernetes >}}) for a list of supported clusters and specific cluster requirements.
+   {{% /alert %}}
 
 1. Use the [`rad env init kubernetes` command]({{< ref rad_env_init_Kubernetes >}}) to initialize a new environment into your current kubectl context:
 

--- a/docs/content/getting-started/tutorial/1-tutorial-environment/index.md
+++ b/docs/content/getting-started/tutorial/1-tutorial-environment/index.md
@@ -27,6 +27,8 @@ A Radius [Kubernetes environment]({{<ref environments-concept>}}) can run in a K
 
 In this step we will be initializing a Radius Kubernetes environment.
 
+> Visit the [Kubernetes platform docs]({{< ref kubernetes >}}) for a list of supported clusters and specific cluster requirements.
+
 1. You can view the current context for kubectl by running:
 
    ```bash

--- a/docs/content/operations/environments/_index.md
+++ b/docs/content/operations/environments/_index.md
@@ -83,6 +83,8 @@ The following example shows an environment configured with Kubernetes as the tar
 ## How-to: Initialize a new environment
 
 1. Begin by deploying a compatible [Kubernetes cluster]({{< ref kubernetes >}})
+> Visit the [Kubernetes platform docs]({{< ref kubernetes >}}) for a list of supported clusters and specific cluster requirements.
+
 1. Ensure your target kubectl context is set as the default:
    ```bash
    kubectl config current-context

--- a/docs/content/operations/environments/_index.md
+++ b/docs/content/operations/environments/_index.md
@@ -83,7 +83,8 @@ The following example shows an environment configured with Kubernetes as the tar
 ## How-to: Initialize a new environment
 
 1. Begin by deploying a compatible [Kubernetes cluster]({{< ref kubernetes >}})
-> Visit the [Kubernetes platform docs]({{< ref kubernetes >}}) for a list of supported clusters and specific cluster requirements.
+
+   *Visit the [Kubernetes platform docs]({{< ref kubernetes >}}) for a list of supported clusters and specific cluster requirements.*
 
 1. Ensure your target kubectl context is set as the default:
    ```bash

--- a/docs/content/operations/platforms/kubernetes/_index.md
+++ b/docs/content/operations/platforms/kubernetes/_index.md
@@ -91,6 +91,10 @@ eksctl create cluster --name my-cluster --region region-code --fargate
 Once deployed and your kubectl context has been set as your default, you can run the following to create a Radius environment and install the control plane:
 
 ```bash
+# Note: make sure to provide a valid (alphanumeric with hyphens)
+# environment name, since the default will not be valid.
+
+# Enter an environment name [arn:aws:eks:region:account:cluster/cluster-name]: cluster-name
 rad env init kubernetes -i
 ```
 

--- a/docs/content/operations/platforms/kubernetes/_index.md
+++ b/docs/content/operations/platforms/kubernetes/_index.md
@@ -91,10 +91,10 @@ eksctl create cluster --name my-cluster --region region-code --fargate
 Once deployed and your kubectl context has been set as your default, you can run the following to create a Radius environment and install the control plane:
 
 ```bash
-# Note: make sure to provide a valid (alphanumeric with hyphens)
-# environment name, since the default will not be valid.
+# Note: The default environment name for EKS is invalid with current env name requirements
+# As part of the init prompts, provide a custom name with only alphanumeric/hyphen characters
 
-# Enter an environment name [arn:aws:eks:region:account:cluster/cluster-name]: cluster-name
+# i.e. Enter an environment name [arn:aws:eks:region:account:cluster/mycluster]: mycluster
 rad env init kubernetes -i
 ```
 

--- a/docs/content/operations/platforms/kubernetes/_index.md
+++ b/docs/content/operations/platforms/kubernetes/_index.md
@@ -85,7 +85,7 @@ rad env init kubernetes -i --public-endpoint-override 'http://localhost:8080'
 Amazon Elastic Kubernetes Service (Amazon EKS) is a managed service that you can use to run Kubernetes on AWS. Learn how to set up an EKS cluster on the [AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
 ```bash
-eksctl create cluster --name my-cluster --region region-code --fargate
+eksctl create cluster --name my-cluster --region region-code
 ```
 
 Once deployed and your kubectl context has been set as your default, you can run the following to create a Radius environment and install the control plane:

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -70,6 +70,20 @@ When running `rad env show`, the `lastmodifiedat` and `createdat` fields display
 
 This will be addressed in an upcoming release.
 
+### Environment creation on EKS fails with default values
+
+When running `rad env init kubernetes` on an EKS cluster, the default environment name for EKS is invalid with current env name requirements.
+
+As a workaround, run `rad env init kubernetes -i`. As part of the init prompts, provide a custom name with only alphanumeric/hyphen characters:
+
+```
+❯ rad env init kubernetes -i
+...
+Enter an environment name [arn:aws:eks:region:account:cluster/mycluster]: mycluster
+```
+
+This will be addressed in an upcoming release.
+
 ## Connectors
 
 ### Dapr resources have application name prefixed to component name


### PR DESCRIPTION
* Added info for workaround for `rad env init kubernetes` on EKS
* Removing `--fargate` from EKS cluster initialization steps

Closes: https://github.com/project-radius/radius/issues/3701