### PR TITLE
Fixing AWS MemoryDB Quickstart 504 timeout

### DIFF
--- a/docs/content/getting-started/quickstarts/aws-quickstart/snippets/aws-memorydb.bicep
+++ b/docs/content/getting-started/quickstarts/aws-quickstart/snippets/aws-memorydb.bicep
@@ -24,6 +24,7 @@ resource memoryDBCluster 'AWS.MemoryDB/Cluster@default' = {
     ACLName: 'open-access'
     SecurityGroupIds: [eksCluster.properties.ClusterSecurityGroupId]
     SubnetGroupName: subnetGroup.name
+    NumReplicasPerShard: 0
   }
 }
 


### PR DESCRIPTION
* Fixes AWS Quickstart 504 timeout
  - Sets `NumReplicasPerShard` to 0, which sets the number of nodes in the cluster to 1 (instead of 2 in the default). This means that the Redis client can successfully query the MemoryDB without having to access multiple nodes.

Closes https://github.com/project-radius/samples/issues/66