### PR TITLE
Fixing resource logs container name

### DIFF
--- a/docs/content/getting-started/quickstarts/quickstart-container-wi/index.md
+++ b/docs/content/getting-started/quickstarts/quickstart-container-wi/index.md
@@ -54,7 +54,7 @@ rad deploy ./app.bicep -p oidcIssuer=<OIDC_ISSUER_URL>
 1. Once deployment completes, read the logs from your running container resource:
 
    ```bash
-   rad resource logs containers mycontainers -a myapp
+   rad resource logs containers mycontainer -a myapp
    ```
 
 2. You should see the contents of the secret from your Key Vault:


### PR DESCRIPTION
`rad resource logs` should use `mycontainer` instead of `mycontainers`