### PR TITLE
Removing sqs sample from docs for now

### DIFF
--- a/docs/content/getting-started/reference-apps/_index.md
+++ b/docs/content/getting-started/reference-apps/_index.md
@@ -36,11 +36,11 @@ no_list: true
   </a>
 </div>
 {{% /card %}}
-{{% card header="[AWS SQS Queues](./aws-sqs)" footer="Learn about how to model AWS SQS Queue resources in Bicep" %}}
+<!-- {{% card header="[AWS SQS Queues](./aws-sqs)" footer="Learn about how to model AWS SQS Queue resources in Bicep" %}}
 <div class="text-center">
   <a href="./aws-sqs">
     <img src="./aws-sqs/aws-logo.png" alt="AWS logo">
   </a>
 </div>
-{{% /card %}}
+{{% /card %}} -->
 {{< /cardpane >}}

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -1,11 +1,10 @@
----
+<!-- ---
 type: docs
 title: "Using AWS SQS Queues with Radius"
 linkTitle: "Using AWS SQS Queues"
 description: "Learn about how to model AWS SQS Queue resources in Bicep and them it in a Radius application"
 weight: 500
-unlisted: true
----
+--- -->
 
 This reference app will show you:
 

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -6,6 +6,8 @@ description: "Learn about how to model AWS SQS Queue resources in Bicep and them
 weight: 500
 --- -->
 
+<!-- DISABLE_ALGOLIA -->
+
 This reference app will show you:
 
 * How to model AWS SQS resources in Bicep

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -4,6 +4,8 @@ title: "Using AWS SQS Queues with Radius"
 linkTitle: "Using AWS SQS Queues"
 description: "Learn about how to model AWS SQS Queue resources in Bicep and them it in a Radius application"
 weight: 500
+toc_hide: true
+hide_summary: true
 --- -->
 
 <!-- DISABLE_ALGOLIA -->

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -44,7 +44,7 @@ This application models two http services: (1) `producer` and (2) `consumer` tha
 
 1. Visit [localhost:3000/send](http://localhost:3000/send) in your browser, this will send a message to the SQS Queue provisioned in `app.bicep`. 
 
-1. Visit [localhost:4000/receive](http://localhost:3000/send) in your browser, this will consume the SQS Queue message and display its contents.
+1. Visit [localhost:4000/receive](http://localhost:4000/receive) in your browser, this will consume the SQS Queue message and display its contents.
 
 ## Cleanup
 

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -1,4 +1,4 @@
-<!-- ---
+---
 type: docs
 title: "Using AWS SQS Queues with Radius"
 linkTitle: "Using AWS SQS Queues"

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -6,7 +6,7 @@ description: "Learn about how to model AWS SQS Queue resources in Bicep and them
 weight: 500
 toc_hide: true
 hide_summary: true
---- -->
+---
 
 <!-- DISABLE_ALGOLIA -->
 

--- a/docs/content/getting-started/reference-apps/aws-sqs/_index.md
+++ b/docs/content/getting-started/reference-apps/aws-sqs/_index.md
@@ -4,6 +4,7 @@ title: "Using AWS SQS Queues with Radius"
 linkTitle: "Using AWS SQS Queues"
 description: "Learn about how to model AWS SQS Queue resources in Bicep and them it in a Radius application"
 weight: 500
+unlisted: true
 ---
 
 This reference app will show you:

--- a/docs/content/getting-started/reference-apps/aws-sqs/snippets/app.bicep
+++ b/docs/content/getting-started/reference-apps/aws-sqs/snippets/app.bicep
@@ -27,9 +27,9 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
 }
 
 resource queue 'AWS.SQS/Queue@default' = {
-  name: '${app_name}-${queue_name}'
+  name: 'sqs-sample-app-${queue_name}'
   properties: {
-    QueueName: 'sqs-sample-${queue_name}'
+    QueueName: 'sqs-sample-app-${queue_name}'
   }
 }
 


### PR DESCRIPTION
See https://github.com/project-radius/samples/issues/106, this sample had issues working that aren't regression from this release. We were debating disabling it from this release due to inconsistencies with the `name` property, we can bring it back once we get it working again.