### PR TITLE
Add instructions to install Dapr where appropriate

### DIFF
--- a/docs/content/author-apps/dapr/index.md
+++ b/docs/content/author-apps/dapr/index.md
@@ -8,6 +8,10 @@ weight: 500
 
 Project Radius offers first-class support for the [Dapr](https://dapr.io) runtime and building blocks to make it easy to make your code fully portable across code and infrastructure.
 
+## Installation 
+
+Follow the instructions [here](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/) to install Dapr in a Kubernetes cluster.
+
 ## Dapr sidecar
 
 A Dapr sidecar allows your services to interact with Dapr building blocks. It is required if your service connects to a Dapr building block resource.

--- a/docs/content/author-apps/dapr/index.md
+++ b/docs/content/author-apps/dapr/index.md
@@ -10,7 +10,7 @@ Project Radius offers first-class support for the [Dapr](https://dapr.io) runtim
 
 ## Installation 
 
-Follow the instructions [here](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/) to install Dapr in a Kubernetes cluster.
+Follow the instructions [here](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/) to install Dapr in your Kubernetes cluster. Once Dapr is installed Radius can begin adding Dapr sidecars to your containers and managing your Dapr components.
 
 ## Dapr sidecar
 

--- a/docs/content/getting-started/quickstarts/dapr-quickstart/_index.md
+++ b/docs/content/getting-started/quickstarts/dapr-quickstart/_index.md
@@ -41,6 +41,7 @@ Dapr integrates directly with Project Radius to provide a simple, easy to use, a
 - [Visual Studio Code](https://code.visualstudio.com/) (recommended)
   - The [Radius VSCode extension]({{< ref "getting-started" >}}) provides syntax highlighting, completion, and linting.
   - You can also complete this quickstart with any basic text editor.
+- [Install Dapr](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/) 
 
 ### Initialize a Radius environment
 

--- a/docs/content/getting-started/reference-apps/container-app-store/1-cas-overview/index.md
+++ b/docs/content/getting-started/reference-apps/container-app-store/1-cas-overview/index.md
@@ -20,6 +20,7 @@ The [Container App Store Microservice](https://github.com/Azure-Samples/containe
 - [rad CLI]({{< ref "getting-started#install-radius-cli" >}})
 - [Docker Desktop](https://www.docker.com/products/docker-desktop) (if running locally)
 - [Dapr CLI](https://docs.dapr.io/getting-started/install-dapr-cli/) (if running locally or on Kubernetes)
+- [Install Dapr](https://docs.dapr.io/operations/hosting/kubernetes/kubernetes-deploy/)
 
 ### Architecture
 


### PR DESCRIPTION
Since we no longer install Dapr as part of Radius installation we need to provide instructions that it should be installed separately.
