### PR TITLE
Change lang to Bicep in rad shortcode

### DIFF
--- a/docs/layouts/shortcodes/rad.html
+++ b/docs/layouts/shortcodes/rad.html
@@ -1,7 +1,7 @@
 {{ $file := .Get "file" }}
 {{ $filePath := (path.Join $.Page.File.Dir $file ) }}
 {{ $fileContents := $filePath | readFile }}
-{{ $lang := "sh" }}
+{{ $lang := "Bicep" }}
 {{ $embed := .Get "embed" | default false }}
 {{ $download := .Get "download" | default false }}
 {{ if $download }}


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Change the lang to bicep in rad shortcode so that comments in the bicep file are greyed out. Most of the code snippets that we showcase in docs are bicep. Would be good to use the native syntax highlighting to improve readability 

In the future when we have terraform snippets we can add language as a parameter to the shortcode

## Issue reference

<!--Please reference the issue this docs PR reference from the radius repo: #[issue number]-->
