### PR TITLE
Add updated Dapr naming conventions to resource schema

### DIFF
--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-http/index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-http/index.md
@@ -21,7 +21,7 @@ A Dapr HTTP Route is defined as a resource within your Application, defined at t
 
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
-| name | y | The name of your resource. | `backend-route`
+| name | y | The name of your resource. Names must contain at most 63 characters, contain only lowercase alphanumeric characters, '-', or '.', start with an alphanumeric character, and end with an alphanumeric character. | `backend-route`
 | location | y | The location of your resource. See [common values]({{< ref "resource-schema.md#common-values" >}}) for more information. | `global`
 | [properties](#properties) | y | Properties of the resource. | [See below](#properties)
 

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
@@ -19,7 +19,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
-| name | y | The name of the pub/sub | `my-pubsub` |
+| name | y | The name of the pub/sub. Names must contain at most 63 characters, contain only lowercase alphanumeric characters, '-', or '.', start with an alphanumeric character, and end with an alphanumeric character. | `my-pubsub` |
 | location | y | The location of your resource. See [common values]({{< ref "resource-schema.md#common-values" >}}) for more information. | `global`
 | [properties](#properties) | y | Properties of the resource. | [See below](#properties)
 

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-secretstore/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-secretstore/_index.md
@@ -21,7 +21,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
-| name | y | The name of the resource. | `my-secretstore` |
+| name | y | The name of the resource. Names must contain at most 63 characters, contain only lowercase alphanumeric characters, '-', or '.', start with an alphanumeric character, and end with an alphanumeric character. | `my-secretstore` |
 | location | y | The location of your resource. See [common values]({{< ref "resource-schema.md#common-values" >}}) for more information. | `global`
 | [properties](#properties) | y | Properties of the resource. | [See below](#properties)
 

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-statestore/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-statestore/_index.md
@@ -21,7 +21,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
-| name | y | The name of the resource. | `my-statestore` |
+| name | y | The name of the resource. Names must contain at most 63 characters, contain only lowercase alphanumeric characters, '-', or '.', start with an alphanumeric character, and end with an alphanumeric character. | `my-statestore` |
 | location | y | The location of your resource. See [common values]({{< ref "resource-schema.md#common-values" >}}) for more information. | `global`
 | [properties](#properties) | y | Properties of the resource. | [See below](#properties)
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Naming conventions for Dapr resources were updated to reflect their schema and documented in the resource schema

## Issue reference

https://github.com/project-radius/radius/issues/5211