### PR TITLE
Fixing swagger file path for UCP API doc page

### DIFF
--- a/.github/config/en-custom.txt
+++ b/.github/config/en-custom.txt
@@ -260,6 +260,7 @@ objectname
 oidcIssuer
 org's
 orgs
+openapi
 pageinfo
 param
 params

--- a/docs/content/reference/api/api-ucp.md
+++ b/docs/content/reference/api/api-ucp.md
@@ -5,4 +5,4 @@ linkTitle: "UCP"
 description: "Detailed reference documentation on the UCP API"
 ---
 
-{{< redoc "swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/ucp.json" >}}
+{{< redoc "swagger/specification/ucp/resource-manager/UCP/preview/2022-09-01-privatepreview/openapi.json" >}}


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

API path was pointing to a older swagger file.

## Issue reference

https://github.com/project-radius/docs/issues/547