### PR TITLE
Switch to single openapi file for Links API reference

### DIFF
--- a/docs/content/reference/api/applications.link/_index.md
+++ b/docs/content/reference/api/applications.link/_index.md
@@ -4,3 +4,5 @@ title: "Applications.Link API reference"
 linkTitle: "Applications.Link"
 description: "Detailed reference documentation on the Applications.Link API"
 ---
+
+{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/openapi.json" >}}

--- a/docs/content/reference/api/applications.link/api-daprInvokeHttpRoutes.md
+++ b/docs/content/reference/api/applications.link/api-daprInvokeHttpRoutes.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/daprInvokeHttpRoutes API reference"
-linkTitle: "daprInvokeHttpRoutes"
-description: "Detailed reference documentation on the Applications.Core/daprInvokeHttpRoutes API"
-slug: "daprInvokeHttpRoutes"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/daprInvokeHttpRoutes.json" >}}

--- a/docs/content/reference/api/applications.link/api-daprpubsubbrokers.md
+++ b/docs/content/reference/api/applications.link/api-daprpubsubbrokers.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/daprPubSubBrokers API reference"
-linkTitle: "daprPubSubBrokers"
-description: "Detailed reference documentation on the Applications.Core/daprPubSubBrokers API"
-slug: "daprPubSubBrokers"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/daprPubSubBrokers.json" >}}

--- a/docs/content/reference/api/applications.link/api-daprsecretstores.md
+++ b/docs/content/reference/api/applications.link/api-daprsecretstores.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/daprSecretStores API reference"
-linkTitle: "daprSecretStores"
-description: "Detailed reference documentation on the Applications.Core/daprSecretStores API"
-slug: "daprSecretStores"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/daprSecretStores.json" >}}

--- a/docs/content/reference/api/applications.link/api-daprstatestores.md
+++ b/docs/content/reference/api/applications.link/api-daprstatestores.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/daprStateStores API reference"
-linkTitle: "daprStateStores"
-description: "Detailed reference documentation on the Applications.Core/daprStateStores API"
-slug: "daprStateStores"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/daprStateStores.json" >}}

--- a/docs/content/reference/api/applications.link/api-extenders.md
+++ b/docs/content/reference/api/applications.link/api-extenders.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/extenders API reference"
-linkTitle: "extenders"
-description: "Detailed reference documentation on the Applications.Core/extenders API"
-slug: "extenders"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/extenders.json" >}}

--- a/docs/content/reference/api/applications.link/api-mongodatabases.md
+++ b/docs/content/reference/api/applications.link/api-mongodatabases.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/mongoDatabases API reference"
-linkTitle: "mongoDatabases"
-description: "Detailed reference documentation on the Applications.Core/mongoDatabases API"
-slug: "mongoDatabases"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/mongoDatabases.json" >}}

--- a/docs/content/reference/api/applications.link/api-rabbitMQMessageQueues.md
+++ b/docs/content/reference/api/applications.link/api-rabbitMQMessageQueues.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/rabbitMQMessageQueues API reference"
-linkTitle: "rabbitMQMessageQueues"
-description: "Detailed reference documentation on the Applications.Core/rabbitMQMessageQueues API"
-slug: "rabbitMQMessageQueues"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/rabbitMQMessageQueues.json" >}}

--- a/docs/content/reference/api/applications.link/api-rediscaches.md
+++ b/docs/content/reference/api/applications.link/api-rediscaches.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/redisCaches API reference"
-linkTitle: "redisCaches"
-description: "Detailed reference documentation on the Applications.Core/redisCaches API"
-slug: "redisCaches"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/redisCaches.json" >}}

--- a/docs/content/reference/api/applications.link/api-sqlDatabases.md
+++ b/docs/content/reference/api/applications.link/api-sqlDatabases.md
@@ -1,9 +1,0 @@
----
-type: api
-title: "Applications.Link/sqlDatabases API reference"
-linkTitle: "sqlDatabases"
-description: "Detailed reference documentation on the Applications.Core/sqlDatabases API"
-slug: "sqlDatabases"
----
-
-{{< redoc "swagger/specification/applications/resource-manager/Applications.Link/preview/2022-03-15-privatepreview/sqlDatabases.json" >}}


### PR DESCRIPTION
The Swagger definition of Links was consolidated into one file in https://github.com/project-radius/radius/pull/4867. 

This PR switches the Link swagger docs to use the new openapi generated file instead of individual files

Closes #559