### PR TITLE
Specify ref for radius checkout so CLI docs are versioned

### DIFF
--- a/.github/scripts/get_docs_version.py
+++ b/.github/scripts/get_docs_version.py
@@ -9,11 +9,13 @@
 # We set the environment variable REL_CHANNEL based on the kind of build. This is used for
 # versioning of our assets.
 #
-# DOCS_CHANNEL is:
-# 'edge': for most builds
-# '1.0': for PR builds
-
 # DOCS_CHANNEL is used to upload assets to different paths
+# 'edge' when targeting edge branch
+# '1.0' when targeting a release branch
+#
+# RELEASE_BRANCH is used when referencing the full release version
+# 'main' when targeting edge branch
+# '1.0' when targeting a release branch
 
 import os
 import sys
@@ -22,19 +24,24 @@ gitRefName = os.getenv("GITHUB_BASE_REF")
 print("GITHUB_BASE_REF: {}".format(gitRefName))
 
 with open(os.getenv("GITHUB_ENV"), "a") as githubEnv:
-    version = "DOCS_CHANNEL=edge"
+    channel = "DOCS_CHANNEL=edge"
+    release_branch = "RELEASE_BRANCH=main"
 
     if gitRefName is None:
-        print("This is not running in github, GITHUB_REF_NAME is null. Assuming a local build. Setting DOCS_CHANNEL to 'edge'")
-        version = "DOCS_CHANNEL=edge"
+        print("This is not running in github, GITHUB_REF_NAME is null. Assuming a local build. Setting DOCS_CHANNEL to 'edge' and RELEASE_BRANCH to 'main'")
     elif gitRefName.lower() == 'edge':
-        print("This is an edge build, setting DOCS_CHANNEL to 'edge'")
-        version = "DOCS_CHANNEL=edge"
+        print("This is an edge build, setting DOCS_CHANNEL to 'edge' and RELEASE_BRANCH to 'main'")
     elif gitRefName.startswith('v'):
-        print("This is a release build, setting DOCS_CHANNEL to version")
-        versionNumber = gitRefName.split('v')[1]
-        version = "DOCS_CHANNEL=" + versionNumber
+        print("This is a release build, setting DOCS_CHANNEL and RELEASE_BRANCH to version")
+        channel = "DOCS_CHANNEL=" + gitRefName.split('v')[1]
+        release_branch = "RELEASE_BRANCH=" + gitRefName + '.0'
+    else:
+        print("This is a non-standard build, setting DOCS_CHANNEL to 'edge' and RELEASE_BRANCH to 'main'")
 
-    print("Setting: {}".format(version))
-    githubEnv.write(version + "\n")
+    print("Setting DOCS_CHANNEL: {}".format(channel))
+    githubEnv.write(channel + "\n")
+
+    print("Setting RELEASE_BRANCH: {}".format(release_branch))
+    githubEnv.write(release_branch + "\n")
+
     sys.exit(0)

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -32,6 +32,8 @@ jobs:
       HUGO_ENV: production
       SWA_BASE: 'wonderful-plant-020417a1e'
     steps:
+      - name: Parse release version and set environment variables
+        run: python ./.github/scripts/get_docs_version.py
       - name: Checkout docs repo
         uses: actions/checkout@v3
         with:
@@ -40,6 +42,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: project-radius/radius
+          ref: ${{ env.RELEASE_BRANCH }}
           path: ./radius
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
       - name: Setup Go ${{ env.GOVER }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -32,12 +32,12 @@ jobs:
       HUGO_ENV: production
       SWA_BASE: 'wonderful-plant-020417a1e'
     steps:
-      - name: Parse release version and set environment variables
-        run: python ./.github/scripts/get_docs_version.py
       - name: Checkout docs repo
         uses: actions/checkout@v3
         with:
           submodules: true
+      - name: Parse release version and set environment variables
+        run: python ./.github/scripts/get_docs_version.py
       - name: Checkout radius repo
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR sets the Docs version number and then checks out the radius repo using the tag of the release. This allows the CLI docs to be generated using the version of the release instead of always `main`.

## Issue reference

Closes #324