### PR TITLE
update memory resource requirements for local Kubernetes clusters

### DIFF
--- a/docs/content/operations/platforms/kubernetes/supported-clusters.md
+++ b/docs/content/operations/platforms/kubernetes/supported-clusters.md
@@ -38,7 +38,7 @@ rad init
 {{% codetab %}}
 [k3d](https://k3d.io) is a lightweight wrapper to run [k3s](https://github.com/rancher/k3s) (Rancher Lab’s minimal Kubernetes distribution) in Docker. 
 
-First, ensure that memory resource is 4GB or more in `Resource` setting of `Preferences` if you're using Docker Desktop. Also make sure you've enabled Rosetta if you're running on an Apple M1 chip:
+First, ensure that memory resource is 8GB or more in `Resource` setting of `Preferences` if you're using Docker Desktop. Also make sure you've enabled Rosetta if you're running on an Apple M1 chip:
 
 ```bash
 softwareupdate --install-rosetta --agree-to-license
@@ -56,7 +56,7 @@ rad init
 {{% codetab %}}
 [Kind](https://kind.sigs.k8s.io/) is a tool for running local Kubernetes clusters inside Docker containers. Use the following setup to create a new cluster and install the Radius control plane, along with a new environment:
 
-First, ensure that memory resource is 4GB or more in `Resource` setting of `Preferences` if you're using Docker Desktop. Also make sure you've enabled Rosetta if you're running on an Apple M1 chip:
+First, ensure that memory resource is 8GB or more in `Resource` setting of `Preferences` if you're using Docker Desktop. Also make sure you've enabled Rosetta if you're running on an Apple M1 chip:
 
 ```bash
 softwareupdate --install-rosetta --agree-to-license


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Minor change to update memory resource requirements for local Kubernetes clusters

## Issue reference

After troubleshooting https://github.com/project-radius/radius/issues/5440 with @nithyatsu we determined that increasing the allocated memory from 4GB to 8GB in Docker resolved the issue. Thus, this PR is a minor update to change the memory requirements in the docs.
