### PR TITLE
Add VSCode extension pointer in first-app

### DIFF
--- a/docs/content/getting-started/first-app/_index.md
+++ b/docs/content/getting-started/first-app/_index.md
@@ -57,6 +57,7 @@ Example output:
 RELEASE   VERSION   BICEP     COMMIT
 0.15.0    v0.15.0   0.11.13   2e60bfb46de73ec5cc70485d53e67f8eaa914ba7
 ```
+To easily author and validate the bicep templates in VSCode, you can install the [Radius Bicep VSCode extension]({{< ref "install.md#setup-vs-code" >}}).
 
 ## 3. Initialize Radius
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Adding an explicit pointer to the Radius bicep VSCode extension on the [First app ](https://docs.radapp.dev/getting-started/first-app/) page to improve visibility.

Though VSCode is optional, would be good to surface this as it might help folks using VSCode 

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this docs PR reference from the radius repo: #[issue number]-->
