### PR TITLE
Updating the recipe name 'redis-kubernetes' to default in first-app

### DIFF
--- a/docs/content/getting-started/first-app/snippets/app-with-redis-snippets.bicep
+++ b/docs/content/getting-started/first-app/snippets/app-with-redis-snippets.bicep
@@ -31,7 +31,7 @@ resource db 'Applications.Link/redisCaches@2022-03-15-privatepreview' = {
     application: application
     environment: environment
     recipe: {
-      name: 'redis-kubernetes'
+      name: 'default'
     }
   }
 }

--- a/docs/content/getting-started/first-app/snippets/app-with-redis-snippets.bicep
+++ b/docs/content/getting-started/first-app/snippets/app-with-redis-snippets.bicep
@@ -30,9 +30,6 @@ resource db 'Applications.Link/redisCaches@2022-03-15-privatepreview' = {
   properties: {
     application: application
     environment: environment
-    recipe: {
-      name: 'default'
-    }
   }
 }
 //REDIS

--- a/docs/content/getting-started/first-app/snippets/app-with-redis.bicep
+++ b/docs/content/getting-started/first-app/snippets/app-with-redis.bicep
@@ -27,8 +27,5 @@ resource db 'Applications.Link/redisCaches@2022-03-15-privatepreview' = {
   properties: {
     application: application
     environment: environment
-    recipe: {
-      name: 'default'
-    }
   }
 }

--- a/docs/content/getting-started/first-app/snippets/app-with-redis.bicep
+++ b/docs/content/getting-started/first-app/snippets/app-with-redis.bicep
@@ -28,7 +28,7 @@ resource db 'Applications.Link/redisCaches@2022-03-15-privatepreview' = {
     application: application
     environment: environment
     recipe: {
-      name: 'redis-kubernetes'
+      name: 'default'
     }
   }
 }


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Looks like the first app docs are still referencing the old recipe name 'redis-kubernetes'. Updating it to 'default'
 cc - @ytimocin , @sk593 @AaronCrawfis 

<!--Please explain the changes you've made-->

## Issue reference

<!--Please reference the issue this docs PR reference from the radius repo: #[issue number]-->
