### PR TITLE
Add aliase to supported clusters page

### DIFF
--- a/docs/content/operations/platforms/kubernetes-platform/supported-clusters.md
+++ b/docs/content/operations/platforms/kubernetes-platform/supported-clusters.md
@@ -6,6 +6,8 @@ description: "Learn how to setup Radius on supported Kubernetes clusters"
 weight: 100
 categories: "How-To"
 tags: ["Kubernetes", "control plane"]
+aliases:
+    - /operations/platforms/kubernetes/supported-clusters/
 ---
 
 ## Minimum version


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
Shared the old supported clusters page URL to customers for Under the Xray session. Adding the old path as alias to redirect old path to new 
<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at bac0ba6</samp>

### Summary
🚚🔄🔗

<!--
1.  🚚 This emoji means "moving" or "relocating", and it can be used to indicate that a page or a file was moved to a different location or folder. This emoji reflects the main change that was done to the page, which was moving it from one folder to another.
2.  🔄 This emoji means "repeat" or "refresh", and it can be used to indicate that a page or a file was updated or modified. This emoji reflects the secondary change that was done to the page, which was updating the page URL to match the new folder name.
3.  🔗 This emoji means "link" or "chain", and it can be used to indicate that a page or a file was linked to another one, or that a redirect or an alias was created. This emoji reflects the tertiary change that was done to the page, which was adding an alias for the old page URL to redirect to the new one.
-->
Added an alias for the supported clusters page URL to redirect from the old path to the new path. This prevents broken links and improves the user experience and SEO of the documentation site.

> _`page URL` changes_
> _old path redirects to new_
> _autumn leaves falling_

### Walkthrough
* Add an alias for the page URL to redirect the old path to the new path ([link](https://github.com/project-radius/docs/pull/598/files?diff=unified&w=0#diff-2977a2e8adace2cc6dab3a93fe86fd20d9a876c86950f38697b1a2d4fe66b211R9-R10))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/project-radius/radius/issues/[issue number]
-->
