### PR TITLE
Add permalinks for categories and tags

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -40,6 +40,10 @@ enableGitInfo = true
 category = "categories"
 tag = "tags"
 
+[permalinks]
+  categories = '/categories/:title-category'
+  tags = '/tags/:title-tag'
+
 # Top Nav Bar
 [[menu.main]]
     name = "Home"


### PR DESCRIPTION
## Description

This PR adds permalinks for categories and tags. This means that when the category "kubernetes" is accessed, it will render to "kubernetes-category" instead of "kubernetes", so that we can continue to use "kubernetes" elsewhere in the docs.

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e486363</samp>

### Summary
:link::card_index_dividers::mag:

<!--
1.  :link: - This emoji represents the concept of links, permalinks, or URLs, and can be used to indicate changes related to the structure or format of the site's links.
2.  :card_index_dividers: - This emoji represents the concept of categories, tags, or taxonomies, and can be used to indicate changes related to the organization or classification of the site's content.
3.  :mag: - This emoji represents the concept of search, SEO, or discovery, and can be used to indicate changes related to the visibility or accessibility of the site's content.
-->
This change updates the `config.toml` file to use custom permalinks for categories and tags. This improves the SEO and usability of the documentation site by using more descriptive URLs.

> _`Hugo` config changed_
> _Custom permalinks for terms_
> _Fall leaves make paths clear_

### Walkthrough
*  Add custom permalinks for categories and tags in Hugo configuration file ([link](https://github.com/project-radius/docs/pull/599/files?diff=unified&w=0#diff-5fbd9920d4a0ae5420b9709cdc967f57514008cae257ca8735d7b8c02e1c77f2R43-R46))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/project-radius/radius/issues/[issue number]
-->
