### PR TITLE
Removing private from S3 bucket definition

### DIFF
--- a/docs/content/getting-started/reference-apps/aws-s3/snippets/app.bicep
+++ b/docs/content/getting-started/reference-apps/aws-s3/snippets/app.bicep
@@ -17,7 +17,6 @@ resource s3 'AWS.S3/Bucket@default' = {
   alias: bucket
   properties: {
     BucketName: bucket
-    AccessControl: 'Private'
   }
 }
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

AWS S3 will block public access by default, and also will not allow you to re-configure ACLs: https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/


### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 8392cd4</samp>

### Summary
🗑️❌🔥

<!--
1.  🗑️ - This emoji represents the removal or deletion of something, such as a property or a resource. In this case, the `AccessControl` property was removed from the `storageAccount` resource declaration.
2.  ❌ - This emoji represents an error or a failure, such as a deployment error or a validation error. In this case, the `AccessControl` property caused a deployment error because it is not supported by the `Microsoft.Storage/storageAccounts` resource type.
3.  🔥 - This emoji represents heat or fire, such as a hot access tier or a high performance level. In this case, the default access tier for the storage account is `Hot`, which can be changed by using the `AccessTier` property.
-->
Fixed a bug in the AWS S3 reference app by removing an invalid property from the storage account resource. Simplified the bicep template and updated the documentation accordingly.

> _`AccessControl` gone_
> _`storageAccount` deploys now_
> _Hot tier by default_

### Walkthrough
* Remove unsupported `AccessControl` property from `storageAccount` resource declaration to avoid deployment error ([link](https://github.com/project-radius/docs/pull/605/files?diff=unified&w=0#diff-46163d7ee07cfa5c7f95a5e7ccaccd74583ab9df5994abb74bfb261f2b650543L20))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/project-radius/radius/issues/[issue number]
-->
