### PR TITLE
Update DaprPubSub and MongoDB docs for `default` recipe support 

### DIFF
--- a/.github/config/en-custom.txt
+++ b/.github/config/en-custom.txt
@@ -78,6 +78,7 @@ PARAMS
 PYTHONAPP
 PowerShell
 Pre
+PubSub
 ProjectRadius
 Quickstart
 Quickstarts

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
@@ -30,7 +30,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
-| [recipe](#recipe)  | n | An object containing the name of the Recipe as well as additional optional parameters to deploy. | `name: 'pubsub-prod'`
+| [recipe](#recipe)  | n | Configuration for the Recipe which will deploy the backing infrastructure. | `name: 'pubsub-prod'`
 | [resources](#resources)  | n | An array of IDs of the underlying resources for the link, in this case could contain the ID of the message broker resource, if a non-generic `kind` is used. | [See below](#resources)
 | type | n | The Dapr component type. Used when resourceProvisioning is `manual`. | `pubsub.kafka` |
 | metadata | n | Metadata for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/) | `brokers: kafkaRoute.properties.url` |

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
@@ -30,7 +30,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
-| [recipe](#recipe)  | n | The recipe to deploy. | `pubsub.id`
+| [recipe](#recipe)  | n | An object containing the name of the Recipe as well as additional optional parameters to deploy. | `name: 'pubsub-prod'`
 | [resources](#resources)  | n | An array of IDs of the underlying resources for the link, in this case could contain the ID of the message broker resource, if a non-generic `kind` is used. | [See below](#resources)
 | type | n | The Dapr component type. Used when resourceProvisioning is `manual`. | `pubsub.kafka` |
 | metadata | n | Metadata for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/) | `brokers: kafkaRoute.properties.url` |

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
@@ -30,7 +30,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
-| [recipe](#recipe)  | n | The recipe to deploy. | `redisCache.id`
+| [recipe](#recipe)  | n | The recipe to deploy. | `pubsub.id`
 | [resources](#resources)  | n | An array of IDs of the underlying resources for the link, in this case could contain the ID of the message broker resource, if a non-generic `kind` is used. | [See below](#resources)
 | type | n | The Dapr component type. Used when resourceProvisioning is `manual`. | `pubsub.kafka` |
 | metadata | n | Metadata for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/) | `brokers: kafkaRoute.properties.url` |

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
@@ -29,9 +29,9 @@ This resource will automatically create and deploy the Dapr component spec for t
 |------|:--------:|-------------|---------|
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
-| mode | y | Specifies how to build the pub/sub resource. Options are to build automatically via 'recipe' or 'resource', or build manually via 'values'. Selection determines which set of fields to additionally require. | `recipe`
+| resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
 | resource | n | The ID of the message broker resource, if a non-generic `kind` is used. For Azure Service Bus this is the namespace ID. | `namespace.id`
-| type | n |The Dapr component type. Used when kind is `generic`. | `pubsub.kafka` |
+| type | n | The Dapr component type. Used when resourceProvisioning is `manual`. | `pubsub.kafka` |
 | metadata | n | Metadata for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/) | `brokers: kafkaRoute.properties.url` |
 | version | n | The version of the Dapr component. See [Dapr components](https://docs.dapr.io/reference/components-reference/supported-pubsub/) for available versions. | `v1` |
 | componentName | n | _(read-only)_ The name of the Dapr component that is generated and applied to the underlying system. Used by the Dapr SDKs or APIs to access the Dapr component. | `myapp-mypubsub` |
@@ -50,7 +50,7 @@ An Azure Service Bus Topic can be used as a Dapr Pub/Sub message broker. Simply 
 
 ## Value backed Link
 
-You can also manually specify the metadata of a Dapr state store. When `mode` is set to `values`, you can specify `type`, `metadata`, and `version` to create a Dapr component spec. These values must match the schema of the intended [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/).
+You can also manually specify the metadata of a Dapr PubSub. When `resourceProvisioning` is set to `manual`, you can specify `type`, `metadata`, and `version` to create a Dapr component spec. These values must match the schema of the intended [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/).
 
 {{< rad file="snippets/dapr-pubsub-kafka.bicep" embed=true marker="//SAMPLE" >}}
 

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/_index.md
@@ -30,7 +30,8 @@ This resource will automatically create and deploy the Dapr component spec for t
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
-| resource | n | The ID of the message broker resource, if a non-generic `kind` is used. For Azure Service Bus this is the namespace ID. | `namespace.id`
+| [recipe](#recipe)  | n | The recipe to deploy. | `redisCache.id`
+| [resources](#resources)  | n | An array of IDs of the underlying resources for the link, in this case could contain the ID of the message broker resource, if a non-generic `kind` is used. | [See below](#resources)
 | type | n | The Dapr component type. Used when resourceProvisioning is `manual`. | `pubsub.kafka` |
 | metadata | n | Metadata for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/) | `brokers: kafkaRoute.properties.url` |
 | version | n | The version of the Dapr component. See [Dapr components](https://docs.dapr.io/reference/components-reference/supported-pubsub/) for available versions. | `v1` |

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-kafka.bicep
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-kafka.bicep
@@ -34,8 +34,7 @@ resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' 
   properties: {
     environment: environment
     application: app.id
-    mode: 'values'
-    type: 'pubsub.kafka'
+    resourceProvisioning: 'manual'    type: 'pubsub.kafka'
     metadata: {
       brokers: kafkaRoute.properties.url
       authRequired: false

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-kafka.bicep
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-kafka.bicep
@@ -34,7 +34,8 @@ resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' 
   properties: {
     environment: environment
     application: app.id
-    resourceProvisioning: 'manual'    type: 'pubsub.kafka'
+    resourceProvisioning: 'manual'    
+    type: 'pubsub.kafka'
     metadata: {
       brokers: kafkaRoute.properties.url
       authRequired: false

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-servicebus.bicep
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-servicebus.bicep
@@ -19,7 +19,9 @@ resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' 
     environment: environment
     application: app.id
     resourceProvisioning: 'manual'
-    resources: namespace.id
+    resources: [
+        { id: namespace.id }
+      ]
   }
 }
 //SAMPLE

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-servicebus.bicep
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-servicebus.bicep
@@ -19,7 +19,7 @@ resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' 
     environment: environment
     application: app.id
     resourceProvisioning: 'manual'
-    resource: namespace.id
+    resources: namespace.id
   }
 }
 //SAMPLE

--- a/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-servicebus.bicep
+++ b/docs/content/reference/resource-schema/link-schema/dapr-schema/dapr-pubsub/snippets/dapr-pubsub-servicebus.bicep
@@ -18,7 +18,7 @@ resource pubsub 'Applications.Link/daprPubSubBrokers@2022-03-15-privatepreview' 
   properties: {
     environment: environment
     application: app.id
-    mode: 'resource'
+    resourceProvisioning: 'manual'
     resource: namespace.id
   }
 }

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
@@ -36,6 +36,7 @@ The `mongodb.com/MongoDatabase` link is a [portable link]({{< ref links-resource
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
+| resource  | n | The ID of the underlying resource for the link. Used when building the link from a resource. | `cosmosDatabase.id`
 | host | n | The MongoDB host name. | `mongo.hello.com`
 | port | n | The MongoDB port. | `4242`
 | [secrets](#secrets) | n | Secrets used when building the link from values. | [See below](#secrets)

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
@@ -36,7 +36,8 @@ The `mongodb.com/MongoDatabase` link is a [portable link]({{< ref links-resource
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
-| resources  | n | The ID of the underlying resource for the link. Used when building the link from a resource. | `cosmosDatabase.id`
+| [recipe](#recipe)  | n | The recipe to deploy. | `mongodb.id`
+| [resources](#resources)  | n | An array of IDs of the underlying resources for the link. | [See below](#resources)
 | host | n | The MongoDB host name. | `mongo.hello.com`
 | port | n | The MongoDB port. | `4242`
 | [secrets](#secrets) | n | Secrets used when building the link from values. | [See below](#secrets)

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
@@ -36,7 +36,7 @@ The `mongodb.com/MongoDatabase` link is a [portable link]({{< ref links-resource
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
-| resource  | n | The ID of the underlying resource for the link. Used when building the link from a resource. | `cosmosDatabase.id`
+| resources  | n | The ID of the underlying resource for the link. Used when building the link from a resource. | `cosmosDatabase.id`
 | host | n | The MongoDB host name. | `mongo.hello.com`
 | port | n | The MongoDB port. | `4242`
 | [secrets](#secrets) | n | Secrets used when building the link from values. | [See below](#secrets)

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/index.md
@@ -35,7 +35,7 @@ The `mongodb.com/MongoDatabase` link is a [portable link]({{< ref links-resource
 |----------|:--------:|-------------|------------|
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
-| resource  | n | The ID of the underlying resource for the link. Used when building the link from a resource. | `cosmosDatabase.id`
+| resourceProvisioning | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. | `manual`
 | host | n | The MongoDB host name. | `mongo.hello.com`
 | port | n | The MongoDB port. | `4242`
 | [secrets](#secrets) | n | Secrets used when building the link from values. | [See below](#secrets)

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-resource.bicep
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-resource.bicep
@@ -17,7 +17,7 @@ resource db 'Applications.Link/mongoDatabases@2022-03-15-privatepreview' = {
   properties: {
     environment: environment
     application: app.id
-    mode: 'resource'
+    resourceProvisioning: 'manual'
     resource: cosmosDatabase
   }
 }

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-resource.bicep
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-resource.bicep
@@ -18,7 +18,7 @@ resource db 'Applications.Link/mongoDatabases@2022-03-15-privatepreview' = {
     environment: environment
     application: app.id
     resourceProvisioning: 'manual'
-    resource: cosmosDatabase
+    resources: cosmosDatabase
   }
 }
 //MONGO

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-resource.bicep
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-resource.bicep
@@ -18,7 +18,9 @@ resource db 'Applications.Link/mongoDatabases@2022-03-15-privatepreview' = {
     environment: environment
     application: app.id
     resourceProvisioning: 'manual'
-    resources: cosmosDatabase
+    resources: [
+        { id: cosmosDatabase }
+      ]
   }
 }
 //MONGO

--- a/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-values.bicep
+++ b/docs/content/reference/resource-schema/link-schema/databases/mongodb/snippets/mongo-values.bicep
@@ -15,7 +15,7 @@ resource db 'Applications.Link/mongoDatabases@2022-03-15-privatepreview' = {
   properties: {
     environment: environment
     application: app.id
-    mode: 'values'
+    resourceProvisioning: 'manual'
     host: 'https://mymongo.cluster.svc.local'
     port: 4242
     secrets: {


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cea4b18</samp>

### Summary
🔧🔄📝

<!--
1.  🔧 - This emoji represents a wrench or a tool, and can be used to indicate a change that involves modifying or adjusting some configuration or settings. In this case, the `mode` property was replaced with the `resourceProvisioning` property in several snippets, which is a change in how the metadata of the Dapr components is specified.
2.  🔄 - This emoji represents a refresh or a sync, and can be used to indicate a change that involves updating or aligning something with another source or standard. In this case, the `resource` property was replaced with the `resourceProvisioning` property in the MongoDB link schema, which is a change that aligns the MongoDB link schema with the Dapr PubSub link schema and avoids confusion with the `resource` property that refers to the underlying resource ID.
3.  📝 - This emoji represents a pencil or a writing, and can be used to indicate a change that involves editing or updating some documentation or text. In this case, the documentation for the Dapr pub/sub link schema was updated to reflect the renaming of the `mode` property to `resourceProvisioning` and to explain what the property means.
-->
Replaced the `mode` property with the `resourceProvisioning` property in the link schemas for Dapr PubSub and MongoDB. This change improves the consistency and clarity of the link schemas and the documentation.

> _No more `mode`, only `resourceProvisioning`_
> _We choose how to create and link our services_
> _Manual or automatic, we have the power_
> _We are the masters of the Dapr schema_

### Walkthrough
*  Rename `mode` property to `resourceProvisioning` and update default value and description in Dapr PubSub link schema ([link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-f95306e840dfe6626c09c27cc57b01993bead1001eb198160bb4657ea2ffec81L32-R34), [link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-f95306e840dfe6626c09c27cc57b01993bead1001eb198160bb4657ea2ffec81L53-R53))
*  Replace `mode` property with `resourceProvisioning` property in Dapr PubSub snippets for Kafka and Service Bus ([link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-f110d465fd99008993fa224ff28877f2d6be10ceccee34a7702bb52631b00724L37-R37), [link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-805eb15c1ce14bfa2b63054c45d0837ad1ef8470258addf5036494ed22b99387L21-R21))
*  Replace `resource` property with `resourceProvisioning` property in MongoDB link schema to avoid confusion with underlying resource ID ([link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-cdc0896d632be4527a3d83128487f066be41d78ca10e63de70aae60f419e37d4L38-R38))
*  Replace `mode` property with `resourceProvisioning` property in MongoDB snippets for Cosmos DB and manual host and port ([link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-42f5eac64ebc6494402e056b36c2e0fd100c49a0734481706ce1eb3ce07ebde6L20-R20), [link](https://github.com/project-radius/docs/pull/606/files?diff=unified&w=0#diff-9a8ccfd2390d707ba62e5a51b6ee18c654b61730d8da9ad3eb33d66f09c6fa6eL18-R18))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/project-radius/radius/issues/[issue number]
-->
