### PR TITLE
Rename administrator guides to operator guides

### DIFF
--- a/.github/scripts/algolia.py
+++ b/.github/scripts/algolia.py
@@ -26,7 +26,7 @@ rankings = {
     "Concepts": 100,
     "Getting started": 0,
     "Developer guides": 200,
-    "Administrator guides": 300,
+    "Operator guides": 300,
     "Reference": 400,
     "Contributing": 500,
     "Home": 600

--- a/docs/content/author-apps/recipes/index.md
+++ b/docs/content/author-apps/recipes/index.md
@@ -11,7 +11,7 @@ slug: recipes
 
 ## Overview
 
-Recipes enable a **separation of concerns** between infrastructure operators and developers by **automating infrastructure deployment**. Developers select the resource they want in their app (_Mongo Database, Redis Cache, Dapr State Store, etc._), and infrastructure teams codify in their environment how these resources should be deployed and configured (_lightweight containers, Azure resources, AWS resources, etc._). When a developer deploys their application and its resources, Recipes automatically deploy the backing infrastructure and bind it to the developer's resources.
+Recipes enable a **separation of concerns** between infrastructure operators and developers by **automating infrastructure deployment**. Developers select the resource they want in their app (_Mongo Database, Redis Cache, Dapr State Store, etc._), and infrastructure operators codify in their environment how these resources should be deployed and configured (_lightweight containers, Azure resources, AWS resources, etc._). When a developer deploys their application and its resources, Recipes automatically deploy the backing infrastructure and bind it to the developer's resources.
 
 <img src="recipes.png" alt="Diagram showing developers adding Redis to their app and operators adding a Recipe that Redis should deploy an Azure Cache for Redis" width=700px >
 

--- a/docs/content/author-apps/recipes/index.md
+++ b/docs/content/author-apps/recipes/index.md
@@ -11,13 +11,14 @@ slug: recipes
 
 ## Overview
 
-Recipes enable a **separation of concerns** between infrastructure teams and developers by **automating infrastructure deployment**. Developers select the resource they want in their app (_Mongo Database, Redis Cache, Dapr State Store, etc._), and infrastructure teams codify in their environment how these resources should be deployed and configured (_lightweight containers, Azure resources, AWS resources, etc._). When a developer deploys their application and its resources, Recipes automatically deploy the backing infrastructure and bind it to the developer's resources.
+Recipes enable a **separation of concerns** between infrastructure operators and developers by **automating infrastructure deployment**. Developers select the resource they want in their app (_Mongo Database, Redis Cache, Dapr State Store, etc._), and infrastructure teams codify in their environment how these resources should be deployed and configured (_lightweight containers, Azure resources, AWS resources, etc._). When a developer deploys their application and its resources, Recipes automatically deploy the backing infrastructure and bind it to the developer's resources.
 
 <img src="recipes.png" alt="Diagram showing developers adding Redis to their app and operators adding a Recipe that Redis should deploy an Azure Cache for Redis" width=700px >
 
 ## Capabilities
 
 ### Select the Recipe that meets your needs
+
 Recipes can be used in any environment, from dev to prod. You can run a default recipe registered in your environment or select the specific Recipe you want to run. To run a default recipe, simply add the resource you want to your app and omit the Recipe name:
 
 {{< rad file="snippets/recipe-link-example.bicep" embed=true marker="//DEFAULT" >}} 

--- a/docs/content/concepts/links-concept/_index.md
+++ b/docs/content/concepts/links-concept/_index.md
@@ -13,7 +13,7 @@ Links provide an **infrastructure abstraction** that enables **portability** for
 
 <img src="links.png" alt="Diagram of Radius Link to infrastructure resource." width="400px" />
 
-For example, when a user specifies a MongoDB link, that link could bind to an Azure CosmosDB, or MongoDB services from other cloud providers. An administrator could even specify the exact configurations of the database resource to spin up when a developer needs a database, enhancing a self-serve workflow.
+For example, when a user specifies a MongoDB link, that link could bind to an Azure CosmosDB, or MongoDB services from other cloud providers. An operator could even specify the exact configurations of the database resource to spin up when a developer needs a database, enhancing a self-serve workflow.
 
 <img src="links-example.png" alt="Diagram of example architecture using or Radius Conntector. Depicts a Radius Container connected to MongoDB Radius Link, which can bind to an Azure CosmosDB, an AWS DynamoDB, or a Mongo Container. " width="700px" />
 

--- a/docs/content/concepts/overview/snippets/appmodel-concept.bicep
+++ b/docs/content/concepts/overview/snippets/appmodel-concept.bicep
@@ -3,7 +3,7 @@ import radius as radius
 param environment string
 
 //SNIPPET
-// Infrastructure team provides database to the application team
+// Infrastructure operators provide database to the application team
 param databaseId string
 
 // Define application

--- a/docs/content/operations/_index.md
+++ b/docs/content/operations/_index.md
@@ -1,7 +1,7 @@
 ---
 type: docs
-title: "Administrator guides"
-linkTitle: "Administrator guides"
+title: "Operator guides"
+linkTitle: "Operator guides"
 description: "Learn about operating Radius environments and apps"
 weight: 40
 ---

--- a/docs/content/operations/custom-recipes/_index.md
+++ b/docs/content/operations/custom-recipes/_index.md
@@ -8,7 +8,7 @@ categories: "How-To"
 tags: ["recipes"]
 ---
 
-Recipes enable a **separation of concerns** between infrastructure teams and developers by **automating infrastructure deployment**.
+Recipes enable a **separation of concerns** between infrastructure operators and developers by **automating infrastructure deployment**.
 
 Learn more in the Recipes overview page:
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Change "administrator" to "operator" to match how we describe roles.

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at cc7e381</samp>

### Summary
🔎🔗🚀

<!--
1.  🔎 - This emoji represents the change to the `rankings` variable in the `.github/scripts/algolia.py` file, which affects the search functionality and relevance of the documentation. The magnifying glass symbolizes the search feature and the improvement of the user experience when looking for information.
2.  🔗 - This emoji represents the change to the term "administrator" in the `docs/content/concepts/links-concept/_index.md` file, which clarifies the concept of Radius links and the role of operators. The link symbolizes the connection between Radius containers and infrastructure resources, as well as the consistency of the terminology across the documentation.
3.  🚀 - This emoji represents the change to the front matter of the `docs/content/operations/_index.md` file, which renames the section from "Administrator guides" to "Operator guides". The rocket symbolizes the launch of the new section name and the importance of the topics related to operating Radius environments and apps.
-->
Updated the documentation to use the term "operator" instead of "administrator" for the role that manages Radius environments and apps. Renamed the "Administrator guides" section to "Operator guides" and adjusted the Algolia ranking script accordingly.

> _`rankings` updated_
> _Operator guides replace_
> _Administrator_

### Walkthrough
*  Rename the "Administrator guides" section to "Operator guides" in the documentation front matter and rankings variable ([link](https://github.com/project-radius/docs/pull/608/files?diff=unified&w=0#diff-1de3b5ebaf1148968eb29dc73486010ef8ae2a0691a39db4738558b420f1723bL29-R29), [link](https://github.com/project-radius/docs/pull/608/files?diff=unified&w=0#diff-8c626b8cca51b3d3e33e908e2aeacfdbc33087e44b2fcbeb59f278827fe1d403L3-R4))
* Replace the term "administrator" with "operator" in the `links-concept/_index.md` file to align with the new role definition ([link](https://github.com/project-radius/docs/pull/608/files?diff=unified&w=0#diff-58d1a7e0db9a6007336ae9419538b2ebe5101ff6d08c994a00312b743839eb35L16-R16))



## Issue reference

Fixes: #538
