### PR TITLE
Add Discord link to community page

### DIFF
--- a/.github/config/en-custom.txt
+++ b/.github/config/en-custom.txt
@@ -402,3 +402,6 @@ valueFrom
 tls
 minimumProtocolVersion
 certificateFrom
+SRG
+ePMKNy
+gg

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -52,10 +52,10 @@ tag = "tags"
     url = "https://github.com/project-radius"
     pre = "<i class='fab fa-github'></i>"
 [[menu.main]]
-    name = "Community"
-    weight = 50
-    url = "https://aka.ms/projectradius"
-    pre = "<i class='fas fa-comment'></i>"
+    name = "Discord"
+    weight = 90
+    url = "https://discord.gg/SRG3ePMKNy"
+    pre = "<i class='fab fa-discord'></i>"
 
 [params]
 copyright = "Project Radius"

--- a/docs/content/community.md
+++ b/docs/content/community.md
@@ -10,7 +10,9 @@ Welcome to the Project Radius community. We are currently in a private release p
 
 ## Discussions
 
-The best way to interact with us currently is through the [Project Radius Preview Teams Channel](https://teams.microsoft.com/l/channel/19%3a97f6300da02447aba041e010c478567e%40thread.tacv2/Preview%2520Discussion?groupId=7eb9839b-5ec6-448d-8447-a820b6bd2cdd&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) or your Radius Core Team contact. Feel free to post into the group discussion so that other community members can jump in and answer as well.
+The best way to interact with us currently is through Discord over at the Radius Discord server:
+
+{{< button link="https://discord.gg/SRG3ePMKNy" text="Radius Discord" newtab="true" >}}
 
 ## Community meetings
 


### PR DESCRIPTION
Adds Discord Link to community page.

Because the community page is behind an authenticated website we can paste this link with a low risk of leaking (if shared it would break someone's NDA)