### PR TITLE
Fix baseURL

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://radapp.dev/"
+baseURL = "https://docs.radapp.dev/"
 languageCode = "en-us"
 title = "Project Radius Docs"
 theme =  "docsy"


### PR DESCRIPTION
Incorrect baseURL for main docs site.

Since we have redirects we didn't catch it right away, but CORS caught us on this one.

Fixes #612 