### PR TITLE
Remove path requirement for website build

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -6,19 +6,11 @@ on:
     branches:
       - edge
       - v*.*
-    paths:
-      - 'docs/**'
-      - '.github/workflows/website.yaml'
-      - '.github/scripts/**'
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - edge
       - v*.*
-    paths:
-      - 'docs/**'
-      - '.github/workflows/website.yaml'
-      - '.github/scripts/**'
 
 jobs:
   build:


### PR DESCRIPTION
Today we require the docs to build before merging any PR

However we also only run the docs build on some paths.

This removes the path filter so it always builds