### PR TITLE
Fix for Validate Bicep failure

### DIFF
--- a/docs/content/reference/resource-schema/link-schema/messaging/rabbitmq/snippets/rabbitmq-manual.bicep
+++ b/docs/content/reference/resource-schema/link-schema/messaging/rabbitmq/snippets/rabbitmq-manual.bicep
@@ -15,7 +15,7 @@ param rmqUsername string
 @secure()
 param rmqPassword string
 param rmqHost string
-param rmqPort string
+param rmqPort int
 param vHost string
 
 resource rabbitmq 'Applications.Link/rabbitmqMessageQueues@2022-03-15-privatepreview' = {


### PR DESCRIPTION
Changed the type of port from string to int.