### PR TITLE
Adding release automation to main branch

### DIFF
--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -1,0 +1,80 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+set -xe
+
+VERSION_NUMBER=$1 # (e.g. 0.1.0)
+REPOSITORY="docs"
+
+if [[ -z "$VERSION_NUMBER" ]]; then
+  echo "Error: VERSION_NUMBER is not set."
+  exit 1
+fi
+
+# VERSION is the version number prefixed by 'v' (e.g. v0.1.0)
+VERSION="v${VERSION_NUMBER}"
+
+# CHANNEL is the major and minor version of the VERSION_NUMBER (e.g. 0.1)
+CHANNEL="$(echo $VERSION_NUMBER | cut -d '.' -f 1,2)"
+
+# CHANNEL_VERSION is the version with the 'v' prefix (e.g. v0.1)
+CHANNEL_VERSION="v${CHANNEL}"
+
+echo "Version number: ${VERSION_NUMBER}"
+echo "Version: ${VERSION}"
+echo "Channel: ${CHANNEL}"
+echo "Channel version: ${CHANNEL_VERSION}"
+
+echo "Creating release branch for ${REPOSITORY}..."
+
+pushd $REPOSITORY
+
+git checkout -B "${CHANNEL_VERSION}"
+
+# In docs/config.toml, change baseURL to https://docs.radapp.dev/ instead of https://edge.docs.radapp.dev/
+awk '{gsub(/baseURL = \"https:\/\/edge\.docs\.radapp.dev\/\"/,"baseURL = \"https:\/\/docs.radapp.dev\/\""); print}' docs/config.toml > docs/config.toml.tmp
+mv docs/config.toml.tmp docs/config.toml
+
+# In docs/config.toml, change version to VERSION instead of edge
+VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
+awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"edge\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+mv docs/config.toml.tmp docs/config.toml
+
+# In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge
+GITHUB_BRANCH_STRING_REPLACEMENT="github_branch = \"${CHANNEL_VERSION}\""
+awk -v REPLACEMENT="${GITHUB_BRANCH_STRING_REPLACEMENT}" '{gsub(/github_branch = \"edge\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+mv docs/config.toml.tmp docs/config.toml
+
+# In docs/config.toml, change chart_version (Helm chart) to VERSION_NUMBER
+CHART_VERSION_STRING_REPLACEMENT="chart_version = \"${VERSION_NUMBER}\""
+awk -v REPLACEMENT="${CHART_VERSION_STRING_REPLACEMENT}" '{gsub(/chart_version = \"[^\n]+\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+mv docs/config.toml.tmp docs/config.toml
+
+# In docs/layouts/partials/hooks/body-end.html, change indexName to radapp-dev instead of radapp-dev-edge
+awk '{gsub(/indexName: '\''radapp-dev-edge'\''/, "indexName: '\''radapp-dev'\''"); print}' docs/layouts/partials/hooks/body-end.html > docs/layouts/partials/hooks/body-end.html.tmp
+mv docs/layouts/partials/hooks/body-end.html.tmp docs/layouts/partials/hooks/body-end.html
+
+# In docs/content/getting-started/install/index.md, update the binary download links with the new version number
+BINARY_STRING_REPLACEMENT=": https:\/\/get\.radapp\.dev\/tools\/rad\/${CHANNEL}\/"
+awk -v REPLACEMENT="${BINARY_STRING_REPLACEMENT}" '{gsub(/: https:\/\/get\.radapp\.dev\/tools\/rad\/[^\/]+\//, REPLACEMENT); print}' docs/content/getting-started/install/index.md > docs/content/getting-started/install/index.md.tmp
+mv docs/content/getting-started/install/index.md.tmp docs/content/getting-started/install/index.md
+
+# Push changes to GitHub
+git add --all
+git commit -m "Update docs for ${VERSION}"
+git push origin "${CHANNEL_VERSION}"
+
+popd

--- a/.github/scripts/validate_semver.py
+++ b/.github/scripts/validate_semver.py
@@ -1,0 +1,45 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# This script validates that the provided version is a valid semver
+
+import os
+import re
+import sys
+
+def main():
+    if len(sys.argv) != 2:
+        print("Usage: validate_semver.py <version>")
+        sys.exit(1)
+
+    # From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+
+    pattern = re.compile(SEMVER_REGEX)
+
+    version = sys.argv[1]
+    match = pattern.search(version)
+
+    # If no match, then return an error (provided version is not valid semver)
+    if match is None:
+        print("Provided version is not valid semver")
+        sys.exit(1)
+    else:
+        print("Provided version is valid semver")
+        sys.exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: Release docs
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Radius version number to use (e.g. 0.22.0, 0.23.0-rc1)'
+        required: true
+        default: ''
+        type: string
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+  GITHUB_EMAIL: 'radiuscoreteam@service.microsoft.com'
+  GITHUB_USER: 'Radius CI Bot'
+
+jobs:
+  release-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          ref: edge
+          path: docs
+      - name: Configure git
+        run: |
+          git config --global user.email "${{ env.GITHUB_EMAIL }}"
+          git config --global user.name "${{ env.GITHUB_USER }}"
+      - name: Ensure inputs.version is valid semver
+        run: |
+          python ./docs/.github/scripts/validate_semver.py ${{ inputs.version }}
+      - name: Parse release channel
+        id: parse_release_channel
+        run: |
+          # CHANNEL is the major and minor version of the VERSION_NUMBER (e.g. 0.1)
+          CHANNEL="$(echo ${{ inputs.version }} | cut -d '.' -f 1,2)"
+          echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+      - name: Release docs
+        run: |
+          ./docs/.github/scripts/release-docs.sh ${{ inputs.version }}
+      - name: Change the default branch
+        run: |
+          gh api \
+          --method PATCH \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/project-radius/docs \
+          -f default_branch='v${{ steps.parse_release_channel.outputs.channel }}'


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0e8cd3b</samp>

### Summary
📚🚀🎁

<!--
1.  📚 - This emoji represents documentation, which is the main purpose of this change. It can also be used for books, education, or learning.
2.  🚀 - This emoji represents launching, deploying, or releasing something, which is what this change does for the docs. It can also be used for space, rockets, or exploration.
3.  🎁 - This emoji represents a gift, a surprise, or a reward, which is what this change offers to the users and developers of the project. It can also be used for celebrations, holidays, or gratitude.
-->
Add a GitHub workflow for releasing docs. The workflow `.github/workflows/release.yaml` allows creating a new docs version by specifying a semantic version number.

> _`docs-release.yml`_
> _A new workflow file_
> _Trigger with version input_

### Walkthrough
* Add a new workflow for releasing docs ([link](https://github.com/radius-project/docs/pull/751/files?diff=unified&w=0#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR1-R49))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
