### PR TITLE
Add connection step to first app experience

### DIFF
--- a/.github/config/en-custom.txt
+++ b/.github/config/en-custom.txt
@@ -464,3 +464,5 @@ PortableResource
 runtime's
 imagePullPolicy
 otelhttp
+RoleBinding
+tcrra

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -120,7 +120,6 @@ In your browser you should see the demo app:
 
 Congrats! You're running your first Radius app. When you're ready to move on to the next step, use <kbd>CTRL</kbd>+ <kbd>C</kbd> to exit the command.
 
-
 ## 5. Add Database
 
 This step will add a database (Redis Cache) to the application.
@@ -165,6 +164,38 @@ Navigate to the Todo List tab and test out the application. Using the Todo page 
 <br /><br />
 
 Press <kbd>CTRL</kbd>+ <kbd>C</kbd> when you are finished with the website.
+
+## 7. View the application connections
+
+Radius connections are more than just environment variables and configuration. You can also access the "application graph" and understand the connections within your application with the following command:
+
+```bash
+rad app connections
+```
+
+You should see the following output, detailing the connections between the `demo` container and the `db` Redis Cache, along with information about the underlying Kubernetes resources running the app:
+
+```
+Displaying application: demo
+
+Name: demo (Applications.Core/containers)
+Connections:
+  demo -> db (Applications.Datastores/redisCaches)
+Resources:
+  demo (kubernetes: apps/Deployment)
+  demo (kubernetes: core/Secret)
+  demo (kubernetes: core/Service)
+  demo (kubernetes: core/ServiceAccount)
+  demo (kubernetes: rbac.authorization.k8s.io/Role)
+  demo (kubernetes: rbac.authorization.k8s.io/RoleBinding)
+
+Name: db (Applications.Datastores/redisCaches)
+Connections:
+  demo (Applications.Core/containers) -> db
+Resources:
+  redis-r5tcrra3d7uh6 (kubernetes: apps/Deployment)
+  redis-r5tcrra3d7uh6 (kubernetes: core/Service)
+```
 
 ## Recap and next steps
 


### PR DESCRIPTION
This PR adds a step to the first app experience that showcases the `rad app connections` command with its output for the first app experience.