### PR TITLE
Add how-to category for manage resource groups

### DIFF
--- a/docs/content/guides/operations/groups/howto-resourcegroups/index.md
+++ b/docs/content/guides/operations/groups/howto-resourcegroups/index.md
@@ -4,6 +4,7 @@ title: "How-To: Manage resource groups"
 linkTitle: "Manage groups"
 description: "Learn how to manage resource groups in Radius"
 weight: 200
+categories: "How-To"
 ---
 
 This guide will walk you through the process of managing resource groups in Radius. For more information on resource groups, see [Resource groups]({{< ref groups >}}).


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d57a78a</samp>

### Summary
:memo::card_file_box::bulb:

<!--
1.  :memo: This emoji represents writing or updating documentation, which is the main purpose of this change.
2.  :card_file_box: This emoji represents adding or updating metadata, which is what the `categories` field is.
3.  :bulb: This emoji represents adding or updating a tip or idea, which is what the document provides as a how-to guide.
-->
Added `categories` metadata to `howto-resourcegroups` document. This enables the document to appear under the "How-To" category on the documentation website.

> _`categories` added_
> _How-To guides for readers_
> _Autumn of learning_

### Walkthrough
* Add `categories` metadata to the front matter of the document `docs/content/guides/operations/groups/howto-resourcegroups/index.md` to group it under "How-To" category ([link](https://github.com/radius-project/docs/pull/831/files?diff=unified&w=0#diff-c634498d9bebe49dcf7587de88b1bf41d2fcbc860f9e551bdb87eaa73f24220bR7))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
