### PR TITLE
Fixing a type to remove "`"

### DIFF
--- a/docs/content/guides/operations/kubernetes/kubernetes-install/index.md
+++ b/docs/content/guides/operations/kubernetes/kubernetes-install/index.md
@@ -20,7 +20,7 @@ Use the [`rad install kubernetes` command]({{< ref rad_install_kubernetes >}}) t
 rad install kubernetes
 
 # Install Radius with tracing and public endpoint override
-rad install kubernetes --set global.zipkin.url=http://jaeger-collector.radius-monitoring.svc.cluster.local:9411/api/v2/spans,rp.publicEndpointOverride=localhost:8081`
+rad install kubernetes --set global.zipkin.url=http://jaeger-collector.radius-monitoring.svc.cluster.local:9411/api/v2/spans,rp.publicEndpointOverride=localhost:8081
 ```
 
 ## Install with Helm


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 13c78b7</samp>

### Summary
:wastebasket::pencil2::memo:

<!--
1.  :wastebasket: This emoji can be used to indicate that something was deleted or removed, such as the extra backtick.
2.  :pencil2: This emoji can be used to indicate that something was edited or corrected, such as the syntax of the command.
3.  :memo: This emoji can be used to indicate that something was documented or updated, such as the consistency of the command with the rest of the documentation.
-->
Fixed a typo in a command in the Kubernetes installation guide. Removed an extra backtick from `docs/content/guides/operations/kubernetes/kubernetes-install/index.md`.

> _A typo removed_
> _Backtick no longer needed_
> _Command runs smoothly_

### Walkthrough
* Fix syntax error in kubectl command by removing extra backtick ([link](https://github.com/radius-project/docs/pull/846/files?diff=unified&w=0#diff-5b1e8b14bb206354b9eccd6444ecf75fc7c08aa75b63c229da510b4ea8ff1345L23-R23))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
