### PR TITLE
Update index.md with '<container_name>' instead of 'frontend'

### DIFF
--- a/docs/content/guides/deploy-apps/howto-troubleshootapps/index.md
+++ b/docs/content/guides/deploy-apps/howto-troubleshootapps/index.md
@@ -26,7 +26,7 @@ Refer to [`rad resource expose`]({{< ref rad_resource_expose >}}) for more detai
 If your Radius Application is unresponsive or does not connect to its dependencies, Use the below command to inspect logs from container:
 
 ```bash
-rad resource logs containers frontend -a <app_name>
+rad resource logs containers <container_name> -a <app_name>
 ```
 
 > Also refer to the [connections section]({{< ref "guides/author-apps/containers/overview#connections" >}}) to know about the naming convention of the environment variables and inspect if your application uses the right variables. 


### PR DESCRIPTION
In the command to 'inspect container logs' update current value 'frontend' with a more generic '<container_name>' similar to other commands in the document

Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

In the command to 'inspect container logs' update current value 'frontend' with a more generic '<container_name>' similar to other commands in the document

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 4fbc6e0</samp>

### Summary
🐛📝🙈

<!--
1.  🐛 - This emoji represents a bug fix, since the original command was incorrect and would not work as expected. Using the container name instead of the resource name is the proper way to view the logs of a specific container in an app.
2.  📝 - This emoji represents a documentation update, since the change affects the instructions and examples in the tutorial. Updating the documentation helps users follow the correct steps and avoid confusion or errors.
3.  🙈 - This emoji represents a mistake or oversight, since the original command was presumably a typo or a copy-paste error that was not caught before publishing. Using this emoji acknowledges the error and shows that it has been fixed.
-->
Fixed a command error in the troubleshooting guide for deploying apps. The `kubectl logs` command now uses the correct container name argument.

> _`logs` command fixed_
> _use container name, not resource_
> _autumn of errors_

### Walkthrough
* Correct the command to view the logs of a specific container using the container name instead of the resource name ([link](https://github.com/radius-project/docs/pull/848/files?diff=unified&w=0#diff-979d3e793fbe3ecd083bf496a328f4efacda1d52c73f25f797d5e6c4e1549d0aL29-R29))


