### PR TITLE
Updates in How To for setting Kubernetes metadata

### DIFF
--- a/docs/content/guides/operations/kubernetes/kubernetes-metadata/index.md
+++ b/docs/content/guides/operations/kubernetes/kubernetes-metadata/index.md
@@ -42,7 +42,6 @@ Kubernetes metadata can be applied at the environment, application, or container
 
 - Applications.Core/containers
 - Applications.Core/gateways
-- Applications.Core/httpRoutes
 
 ### Metadata processing order
 

--- a/docs/content/guides/operations/kubernetes/kubernetes-metadata/index.md
+++ b/docs/content/guides/operations/kubernetes/kubernetes-metadata/index.md
@@ -42,6 +42,7 @@ Kubernetes metadata can be applied at the environment, application, or container
 
 - Applications.Core/containers
 - Applications.Core/gateways
+- Applications.Core/httpRoutes
 
 ### Metadata processing order
 
@@ -57,7 +58,7 @@ In the case where layers have conflicting keys (_i.e. Application and Container 
 
 ## Reserved keys
 
-Certain labels/annotations have special uses to Radius internally and are not allowed to be overridden by user. Labels/Annotations with keys that have a prefix : `radius.dev/` will be ignored during processing.
+Certain labels/annotations have special uses to Radius internally and are not allowed to be overridden by user. Labels/Annotations with keys that have a prefix : `radapp.io/` will be ignored during processing.
 
 ## Extension processing order
 
@@ -93,9 +94,9 @@ Labels:           key1=appValue1
                   key2=containerValue2
                   team.contact.name=Frontend
                   team.contact.alias=frontend-eng
-                  radius.dev/application=myapp
-                  radius.dev/resource=frontend
-                  radius.dev/resource-type=applications.core-containers
+                  radapp.io/application=myapp
+                  radapp.io/resource=frontend
+                  radapp.io/resource-type=applications.core-containers
                   ...
 Annotations:      prometheus.io/port: 9090
                   prometheus.io/scrape: true
@@ -111,9 +112,9 @@ The labels & annotations were set based on the following:
 | `team.key2` | `containerValue2` | Container value overrides application value
 | `team.contact.name` | `Frontend` | Container value overrides application value
 | `team.contact.alias` | `frontend-eng` | Container value overrides application value
-| `radius.dev/application` | `myapp` | Radius-injected label
-| `radius.dev/resource` | `frontend` | Radius-injected label
-| `radius.dev/resource-type` | `applications.core-containers` | Radius-injected label
+| `radapp.io/application` | `myapp` | Radius-injected label
+| `radapp.io/resource` | `frontend` | Radius-injected label
+| `radapp.io/resource-type` | `applications.core-containers` | Radius-injected label
 | **Annotations**
 | `prometheus.io/port` | `9090` | Application annotation is applied
 | `prometheus.io/scrape` | `true `| Application annotation is applied


### PR DESCRIPTION
* Applications.Core/httpRoutes resource was missing from the list.
* References to `radius.dev` needed to be updated.

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 647d34d</samp>

### Summary
📝🏷️🛣️

<!--
1.  📝 - This emoji represents documentation or writing, and can be used to indicate that this change updates the documentation on Kubernetes metadata.
2.  🏷️ - This emoji represents labels or tags, and can be used to indicate that this change affects the reserved labels/annotations that have the `radapp.io/` prefix.
3.  🛣️ - This emoji represents roads or routes, and can be used to indicate that this change involves the `httpRoutes` resource type that supports cascading metadata.
-->
Update Kubernetes metadata documentation to use `radapp.io/` prefix and include `httpRoutes` resource type. This improves clarity and consistency for users working with metadata on the Radius platform.

> _`radapp.io/` prefix_
> _cascading metadata docs_
> _autumn leaves update_

### Walkthrough
*  Update the reserved prefix for metadata labels/annotations from `radius.dev/` to `radapp.io/` to match the new domain name of the Radius platform and avoid conflicts ([link](https://github.com/radius-project/docs/pull/857/files?diff=unified&w=0#diff-3c30f4ddc51c75b9980a6ad8453e01453fdd4cadf996b381620b65ffd855a736L60-R61), [link](https://github.com/radius-project/docs/pull/857/files?diff=unified&w=0#diff-3c30f4ddc51c75b9980a6ad8453e01453fdd4cadf996b381620b65ffd855a736L96-R99), [link](https://github.com/radius-project/docs/pull/857/files?diff=unified&w=0#diff-3c30f4ddc51c75b9980a6ad8453e01453fdd4cadf996b381620b65ffd855a736L114-R117))
* Add `Applications.Core/httpRoutes` to the list of resource types that support cascading metadata, allowing metadata inheritance from the application level ([link](https://github.com/radius-project/docs/pull/857/files?diff=unified&w=0#diff-3c30f4ddc51c75b9980a6ad8453e01453fdd4cadf996b381620b65ffd855a736R45))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
