### PR TITLE
Fixed old reference to dev Recipe name

### DIFF
--- a/docs/content/tutorials/tutorial-recipe/index.md
+++ b/docs/content/tutorials/tutorial-recipe/index.md
@@ -71,8 +71,8 @@ Developers don't need to specify what cloud resources they're using in their app
    default   Applications.Datastores/redisCaches     bicep                            radius.azurecr.io/recipes/local-dev/rediscaches:latest
    ```
 
-{{< alert title="💡 Dev Recipes" color="info" >}}
-Dev environments are preloaded with [`dev` Recipes]({{< ref "guides/recipes/overview#use-community-dev-recipes" >}}), a set of Recipes that allow you to quickly get up and running with lightweight containerized infrastructure. In This how-to guide, the dev Redis Recipe deploys a lightweight Redis container into your Kubernetes cluster.
+{{< alert title="💡 Local-dev Recipes" color="info" >}}
+Dev environments are preloaded with [local-dev Recipes]({{< ref "guides/recipes/overview#use-community-dev-recipes" >}}), a set of Recipes that allow you to quickly get up and running with lightweight containerized infrastructure. In This how-to guide, the dev Redis Recipe deploys a lightweight Redis container into your Kubernetes cluster.
 
 When a Recipe is named "default" it will be used by default when deploying resources when a Recipe is not specified.
 {{< /alert >}}
@@ -122,7 +122,7 @@ Note that no Recipe name is specified with 'db', so it will be using the default
    kubectl get pods -n default-recipes
    ```
 
-   You will see your 'frontend' container, along with the Redis cache that was automatically created by the default dev Recipe:
+   You will see your 'frontend' container, along with the Redis cache that was automatically created by the default local-dev Recipe:
 
    ```
    NAME                                   READY   STATUS    RESTARTS   AGE

--- a/docs/content/tutorials/tutorial-recipe/index.md
+++ b/docs/content/tutorials/tutorial-recipe/index.md
@@ -72,7 +72,7 @@ Developers don't need to specify what cloud resources they're using in their app
    ```
 
 {{< alert title="💡 Local-dev Recipes" color="info" >}}
-Dev environments are preloaded with [local-dev Recipes]({{< ref "guides/recipes/overview#use-community-dev-recipes" >}}), a set of Recipes that allow you to quickly get up and running with lightweight containerized infrastructure. In This how-to guide, the dev Redis Recipe deploys a lightweight Redis container into your Kubernetes cluster.
+Development environments are preloaded with [local-dev Recipes]({{< ref "guides/recipes/overview#use-community-dev-recipes" >}}), a set of Recipes that allow you to quickly get up and running with lightweight containerized infrastructure. In this how-to guide, the local-dev Recipe for Redis deploys a lightweight Redis container into your Kubernetes cluster.
 
 When a Recipe is named "default" it will be used by default when deploying resources when a Recipe is not specified.
 {{< /alert >}}


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.dev/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Change old references for local-dev Recipes

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91e4238</samp>

### Summary
📝🔧🚀

<!--
1.  📝 This emoji represents the documentation update that reflects the new name for local-dev Recipes.
2.  🔧 This emoji represents the change in the command output example that shows how to run a local-dev Recipe using the `sf` CLI.
3.  🚀 This emoji represents the benefit of using local-dev Recipes, which is to quickly launch a local development environment for Salesforce projects.
-->
Rename `dev Recipes` to `local-dev Recipes` in tutorial documentation. This reflects the updated terminology for Recipes that run on local machines.

> _Sing, O Muse, of the skillful coder who changed the names_
> _Of the dev Recipes, those tools of craft and cunning,_
> _To local-dev Recipes, to match the new conventions_
> _That govern the creation of the works of art sublime._

### Walkthrough
*  Rename "dev Recipes" to "local-dev Recipes" in the tutorial text and output example ([link](https://github.com/radius-project/docs/pull/863/files?diff=unified&w=0#diff-4d2f3e564713bf8d21829b2c114bfc9b57bd646b6f2e8cc14fb04c9909c6a244L74-R75), [link](https://github.com/radius-project/docs/pull/863/files?diff=unified&w=0#diff-4d2f3e564713bf8d21829b2c114bfc9b57bd646b6f2e8cc14fb04c9909c6a244L125-R125))
*  Update the link to the local-dev Recipes documentation page in the tutorial text ([link](https://github.com/radius-project/docs/pull/863/files?diff=unified&w=0#diff-4d2f3e564713bf8d21829b2c114bfc9b57bd646b6f2e8cc14fb04c9909c6a244L74-R75))



## Issue reference
