### PR TITLE
Add redirect for radapp.dev

### DIFF
--- a/.github/workflows/redirect.yml
+++ b/.github/workflows/redirect.yml
@@ -1,0 +1,48 @@
+name: Radius Redirect
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - edge
+      - v*.*
+    paths: 
+      - 'redirect/**'
+      - '.github/workflows/redirect.yml'
+  pull_request:
+    branches:
+      - edge
+      - v*.*
+    paths: 
+      - 'redirect/**'
+      - '.github/workflows/redirect.yml'
+
+jobs:
+  deploy-website:
+    name: Deploy Redirect Website
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Deploy staging site
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.SWA_REDIRECT_TOKEN }}
+          action: "upload"
+          app_location: "redirect/src"
+          skip_api_build: true
+          skip_app_build: true
+
+  close_pr_site:
+    name: Close PR Staging Site
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.SWA_REDIRECT_TOKEN }}
+          action: "close"

--- a/redirect/README.md
+++ b/redirect/README.md
@@ -1,0 +1,3 @@
+# Redirect Page
+
+Our current domain, `radapp.io`, is the homepage for Radius. We previously operated on `radapp.dev` and may still have some remaining links to that domain. This directory contains a redirect page that we host on `radapp.dev` to redirect to `radapp.io`.

--- a/redirect/src/index.html
+++ b/redirect/src/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to https://radapp.io</title>
+    <meta http-equiv="refresh" content="0; URL=https://radapp.io">
+  </head>
+  <body>
+    <p>Please wait while you are redirected to https://radapp.io</p>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a simple HTML file along with a pipeline to deploy it to a static web app in order to redirect radapp.dev to radapp.io