### PR TITLE
Add rewrite rule for docs.radapp.dev

### DIFF
--- a/docs/content/web.config
+++ b/docs/content/web.config
@@ -6,9 +6,9 @@
                 <rule name="Redirect to docs.radapp.io" stopProcessing="true">
                     <match url=".*" />
                     <conditions>
-                        <add input="{HTTP_HOST}" pattern="^docs\.radapp\.dev$" />
+                        <add input="{HTTP_HOST}" pattern="^docs\.radapp\.dev$|^edge\.docs\.radapp\.dev$" />
                     </conditions>
-                    <action type="Redirect" url="https://docs.radapp.io/{R:0}" />
+                    <action type="Redirect" url="https://{HTTP_HOST}/{R:0}" />
                 </rule>
             </rules>
         </rewrite>

--- a/docs/content/web.config
+++ b/docs/content/web.config
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <system.webServer>
-        <staticContent>
-            <remove fileExtension=".bicep" />
-            <mimeMap fileExtension=".bicep" mimeType="text/plain" />
-            <remove fileExtension=".json" />
-            <mimeMap fileExtension=".json" mimeType="application/json" />
-            <remove fileExtension=".yaml" />
-            <mimeMap fileExtension=".yaml" mimeType="application/yaml" />
-        </staticContent>
+        <rewrite>
+            <rules>
+                <rule name="Redirect to docs.radapp.io" stopProcessing="true">
+                    <match url=".*" />
+                    <conditions>
+                        <add input="{HTTP_HOST}" pattern="^docs\.radapp\.dev$" />
+                    </conditions>
+                    <action type="Redirect" url="https://docs.radapp.io/{R:0}" />
+                </rule>
+            </rules>
+        </rewrite>
     </system.webServer>
 </configuration>

--- a/docs/content/web.config
+++ b/docs/content/web.config
@@ -8,7 +8,7 @@
                     <conditions>
                         <add input="{HTTP_HOST}" pattern="^docs\.radapp\.dev$|^edge\.docs\.radapp\.dev$" />
                     </conditions>
-                    <action type="Redirect" url="https://{HTTP_HOST}/{R:0}" />
+                    <action type="Redirect" url="https://docs.radapp.io/{R:0}" />
                 </rule>
             </rules>
         </rewrite>

--- a/docs/content/web.config
+++ b/docs/content/web.config
@@ -3,10 +3,17 @@
     <system.webServer>
         <rewrite>
             <rules>
+                <rule name="Redirect to edge.docs.radapp.io" stopProcessing="true">
+                    <match url=".*" />
+                    <conditions>
+                        <add input="{HTTP_HOST}" pattern="^edge\.docs\.radapp\.dev$" />
+                    </conditions>
+                    <action type="Redirect" url="https://edge.docs.radapp.io/{R:0}" />
+                </rule>
                 <rule name="Redirect to docs.radapp.io" stopProcessing="true">
                     <match url=".*" />
                     <conditions>
-                        <add input="{HTTP_HOST}" pattern="^docs\.radapp\.dev$|^edge\.docs\.radapp\.dev$" />
+                        <add input="{HTTP_HOST}" pattern="^docs\.radapp\.dev$" />
                     </conditions>
                     <action type="Redirect" url="https://docs.radapp.io/{R:0}" />
                 </rule>


### PR DESCRIPTION
This PR adds a rewrite rule that redirects all request to docs.radpp.io instead of docs.radapp.dev