### PR TITLE
Fix link to concepts on docs home page

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -27,7 +27,7 @@ Radius is a cloud native application platform.  It enables developers and IT ope
   {{< /card >}}
 {{< /cardpane >}}
 {{< cardpane >}}
-  {{< card header="**💭 Concepts**" footer="[**Learn the concepts →**]({{< ref tutorials >}})" >}}
+  {{< card header="**💭 Concepts**" footer="[**Learn the concepts →**]({{< ref concepts >}})" >}}
   Learn about the background and concepts behind Radius with in-depth explanations. We'll cover the main concepts and how Radius works, so you have the broader context to deeply understand Radius and use it most effectively.
   {{< /card >}}
   {{< card header="**🧾 Reference**" footer="[**Visit reference material →**]({{< ref guides >}})" >}}


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There seem to be copy/paste error. The link for the "Concepts" was actually directing to the "Tutorials" section

Updated the reference to concepts and tested locally.

I would also add that the links do not work on the Codespace, but do work Locally.

When starting server on code space, the docs will be at a url such as
`https://effective-space-computing-machine-q966j4q5x6c9wrx-1313.app.github.dev/`

Clinking a reference attempts to direct to `http://localhost:1313/tutorials/` but that doesn't exist.

There is probably a way to configure Hugo to use absolute urls and supply the base as environment variable when setting up the container / code space, but that would be out of scope.

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58fe6df</samp>

### Summary
🛠️📚🔗

<!--
1.  🛠️ - This emoji represents a wrench or a tool, and it can be used to indicate a bug fix or a minor improvement to the functionality or usability of a feature. In this case, the emoji conveys that the footer link was fixed and now works as expected.
2.  📚 - This emoji represents a stack of books, and it can be used to indicate a change related to documentation, learning resources, or educational content. In this case, the emoji conveys that the change affects the Concepts section, which provides conceptual information and explanations about the topic.
3.  🔗 - This emoji represents a link or a chain, and it can be used to indicate a change related to URLs, hyperlinks, references, or connections between different parts of a website or an application. In this case, the emoji conveys that the change involves updating the destination of the footer link to point to the correct page.
-->
Fixed a broken footer link in the Concepts card on the homepage. The link now points to the `concepts/_index.md` page instead of the `tutorials/_index.md` page.

> _`Concepts` card fixed_
> _Footer link was not correct_
> _Now it points to fall_

### Walkthrough
* Fix the footer link for Concepts card to point to the correct page ([link](https://github.com/radius-project/docs/pull/905/files?diff=unified&w=0#diff-5d9ba8bc1a568741b44ccc852748ca739d71f89dc1ac05a9f8d3787a064a549dL30-R30))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
