### PR TITLE
Add DCO instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,23 @@
 # Contributing to Radius documentation
 
 Thank you for your interesting in contributing to the Radius documentation! For more information please refer to [https://docs.radapp.io/community/contributing/docs/](https://docs.radapp.io/community/contributing/docs/)
+
+## Developer Certificate of Origin
+
+The Radius project follows the [Developer Certificate of Origin](https://developercertificate.org/). This is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+
+Contributors sign-off that they adhere to these requirements by adding a Signed-off-by line to commit messages.
+
+```
+This is my commit message
+
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+Git even has a -s command line option to append this automatically to your commit message:
+
+```
+$ git commit -s -m 'This is my commit message'
+```
+
+Visual Studio Code has a setting, `git.alwaysSignOff` to automatically add a Signed-off-by line to commit messages. Search for "sign-off" in VS Code settings to find it and enable it.

--- a/docs/content/community/contributing/contributing-docs/index.md
+++ b/docs/content/community/contributing/contributing-docs/index.md
@@ -89,6 +89,26 @@ It's easy to get up and running with a GitHub Codespace. This will give you a fu
 
 3. Navigate to `http://localhost:1313/`
 
+## Developer Certificate of Origin
+
+The Radius project follows the [Developer Certificate of Origin](https://developercertificate.org/). This is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+
+Contributors sign-off that they adhere to these requirements by adding a Signed-off-by line to commit messages.
+
+```
+This is my commit message
+
+Signed-off-by: Random J Developer <random@developer.example.org>
+```
+
+Git even has a -s command line option to append this automatically to your commit message:
+
+```
+$ git commit -s -m 'This is my commit message'
+```
+
+Visual Studio Code has a setting, `git.alwaysSignOff` to automatically add a Signed-off-by line to commit messages. Search for "sign-off" in VS Code settings to find it and enable it.
+
 ## Types of docs
 
 There are 5 types of docs in Radius:


### PR DESCRIPTION
This PR adds instructions for developer certificate of origin for the docs repository