### PR TITLE
Fix typo in comparison doc

### DIFF
--- a/docs/content/concepts/faq/index.md
+++ b/docs/content/concepts/faq/index.md
@@ -79,7 +79,7 @@ Yes. Radius has first-class support for [Dapr building blocks]({{< ref "/guides/
 
 ### How does Radius compare to Kubernetes?
 
-[Kubernetes](https://kubernetes.io/) is an open-source system for automating deployment, scaling, and management of containerized applications and custom resources. =
+[Kubernetes](https://kubernetes.io/) is an open-source system for automating deployment, scaling, and management of containerized applications and custom resources.
 
 Radius leverages Kubernetes in two ways:
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0644977</samp>

### Summary
:pencil2::books::cloud:

<!--
1.  :pencil2: This emoji means "fix typos or improve grammar" and is suitable for the change that corrects the `=` sign.
2.  :books: This emoji means "documentation" and is suitable for the change that updates the documentation of the Radius project.
3.  :cloud: This emoji means "cloud services or infrastructure" and is suitable for the change that relates to the Radius platform, which is a cloud-native application platform.
-->
Fix a typo in `docs/content/concepts/faq/index.md` and update the documentation of the Radius project.

> _`=` sign removed_
> _Documentation improved_
> _A fresh spring for Radius_

### Walkthrough
* Fix a typo by removing an extra `=` sign in the first paragraph of `docs/content/concepts/faq/index.md` ([link](https://github.com/radius-project/docs/pull/932/files?diff=unified&w=0#diff-69df4f813a3c3e019a80a4a10de4aaaf256f9699048b08cd9383c1985a6d73d4L82-R82))



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
