### PR TITLE
Update index.md

### DIFF
--- a/docs/content/guides/operations/kubernetes/overview/index.md
+++ b/docs/content/guides/operations/kubernetes/overview/index.md
@@ -32,7 +32,7 @@ Radius resources, when deployed to a Kubernetes environment, are mapped to one o
 
 Application-scoped resources are by default generated in a new Kubernetes namespace with the name format `'<envNamespace>-<appname>'`. This prevents multiple applications with resources of the same name from conflicting with each other.
 
-For example, let's take an application named `'myapp'` with a container named `'frontend'`. This application is deployed into an environment configured with with the `'default'` namespace. A Kubernetes Deployment named `'frontend'` is now deployed into the namespace `'default-myapp'`.
+For example, let's take an application named `'myapp'` with a container named `'frontend'`. This application is deployed into an environment configured with the `'default'` namespace. A Kubernetes Deployment named `'frontend'` is now deployed into the namespace `'default-myapp'`.
 
 If you wish to override the default behavior and specify your own namespace for application resources to be generated into, you can leverage the [`kubernetesNamespace` application extension]({{< ref "application-schema#kubernetesNamespace" >}}). All application-scoped resources will now be deployed into this namespace instead.
 


### PR DESCRIPTION
Minor typo - duplicate word 'with'

Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Removed a duplicate language - 'with' 

### Auto-generated description

<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9c80947</samp>

### Summary
:memo::pencil2::mag:

<!--
1.  :memo: This emoji is often used for documentation updates or fixes, and it represents a memo or a document.
2.  :pencil2: This emoji is also used for documentation or minor edits, and it represents a pencil or writing.
3.  :mag: This emoji is used for finding or fixing bugs, typos, or errors, and it represents a magnifying glass or searching.
-->
Fix a typo in the Kubernetes overview guide. Remove a duplicated word in `docs/content/guides/operations/kubernetes/overview/index.md`.

> _`with` was repeated_
> _a typo in the docs fixed_
> _autumn leaves fall gently_

### Walkthrough
* Fix typo in documentation (`[link](https://github.com/radius-project/docs/pull/995/files?diff=unified&w=0#diff-91273079f6b569bd0f8f10f0e95fad225a427462dcd7fbc13c8680bcde494349L35-R35)`)



## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
