### PR TITLE
Remove copilot4prs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,10 +15,6 @@ In addition, please fill out the following to help reviewers understand this pul
 
 <!--Please explain the changes you've made-->
 
-### Auto-generated description
-
-copilot:all
-
 ## Issue reference
 
 <!--


### PR DESCRIPTION
This PR removes Copilot for PRs, given its deprecation on 12/15/2023