### PR TITLE
Update Supported Sources for Terraform Recipes

### DIFF
--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -19,7 +19,7 @@ Recipes enable a **separation of concerns** between IT operators and developers 
 | Language | Supported sources | Notes |
 |----------|-------------------|-------|
 | [Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/) | [OCI registries](https://opencontainers.org/) | Supports Azure, AWS, and Kubernetes
-| [Terraform](https://developer.hashicorp.com/terraform/docs) | [Public accessible module sources](https://developer.hashicorp.com/terraform/language/modules/sources) | Supports Azure, AWS, and Kubernetes providers<br />Other providers not yet configurable
+| [Terraform](https://developer.hashicorp.com/terraform/docs) | [Public module sources](https://developer.hashicorp.com/terraform/language/modules/sources)<br />Private modules not yet configurable | Supports Azure, AWS, and Kubernetes providers<br />Other providers not yet configurable
 
 ### Select the Recipe that meets your needs
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -19,7 +19,7 @@ Recipes enable a **separation of concerns** between IT operators and developers 
 | Language | Supported sources | Notes |
 |----------|-------------------|-------|
 | [Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/) | [OCI registries](https://opencontainers.org/) | Supports Azure, AWS, and Kubernetes
-| [Terraform](https://developer.hashicorp.com/terraform/docs) | [Public Terraform registries](https://registry.terraform.io/) | Supports Azure, AWS, and Kubernetes providers<br />Other providers not yet configurable
+| [Terraform](https://developer.hashicorp.com/terraform/docs) | [Public accessible module sources](https://developer.hashicorp.com/terraform/language/modules/sources) | Supports Azure, AWS, and Kubernetes providers<br />Other providers not yet configurable
 
 ### Select the Recipe that meets your needs
 


### PR DESCRIPTION
## Description

We recently validated that module sources other than TF module registries are also supported with the current flow, as long as they are publicly accessible. The testing was done with github repo URLs and S3 buckets. So updating the docs to reflect the list of supported sources.

## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
