### PR TITLE
Fixes incorrect `rad workspace switch` example

### DIFF
--- a/docs/content/guides/operations/workspaces/overview/index.md
+++ b/docs/content/guides/operations/workspaces/overview/index.md
@@ -61,7 +61,7 @@ rad workspace delete -w myenv
 [rad workspace switch]({{< ref rad_workspace_switch >}}) switches the default workspace:
 
 ```bash
-rad env switch -e myenv
+rad workspace switch -w myworkspace
 ```
 
 {{% /codetab %}}


### PR DESCRIPTION
**Please follow this checklist before submitting:**

- [X] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] ~New file and folder names are globally unique~
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Updated incorrect example of CLI command for `rad workspace switch` which was using `rad env switch`.
