### PR TITLE
Update broken link to Docs Contribution Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The [rad CLI](https://github.com/radius-project/radius/tree/main/cmd/rad) refere
 
 ## 👨‍💻 Contributing
 
-Visit the [docs contribution guide](https://radapp.io/contributing/contributing-docs/) to learn how to contribute to the docs.
+Visit the [docs contribution guide](https://docs.radapp.io/community/contributing/docs/) to learn how to contribute to the docs.
 
 ### Local server
 


### PR DESCRIPTION
**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] ~New file and folder names are globally unique~
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Fixed broken old link to contribution guide in Readme, now links to [docs.radapp.io](https://docs.radapp.io/community/contributing/docs/) which is also used in the PR template.
