### PR TITLE
Update limitations page to warn users that naming a gateway with the same name as a container causes an error

### DIFF
--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -38,7 +38,7 @@ See [app name constraints]({{< ref "resource-schema.md#common-values" >}}) for m
 
 Deploying a Radius Application that contains a gateway resource and a container resource that share a name will result in an error being thrown during the deployment process.
 
-As a workaround users can just name the respective resources differently.
+As a workaround make sure to use distinct names for both containers and gateways.
 
 ## rad CLI
 

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -34,6 +34,12 @@ As a workaround do not use underscores in resource names. Additional validation 
 
 See [app name constraints]({{< ref "resource-schema.md#common-values" >}}) for more information.
 
+### Gateway resources and container resources cannot share names names
+
+Deploying a Radius Application that contains a gateway resource and a container resource that share a name will result in an error being thrown during the deployment process.
+
+As a workaround users can just name the respective resources differently.
+
 ## rad CLI
 
 ### Application and resource names are lower-cased after deployment

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -34,7 +34,7 @@ As a workaround do not use underscores in resource names. Additional validation 
 
 See [app name constraints]({{< ref "resource-schema.md#common-values" >}}) for more information.
 
-### Gateway resources and container resources cannot share names names
+### Gateway resources and container resources cannot share names
 
 Deploying a Radius Application that contains a gateway resource and a container resource that share a name will result in an error being thrown during the deployment process.
 

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -36,7 +36,7 @@ See [app name constraints]({{< ref "resource-schema.md#common-values" >}}) for m
 
 ### Gateway resources and container resources cannot share names
 
-Deploying a Radius Application that contains a gateway resource and a container resource that share a name will result in an error being thrown during the deployment process.
+Deploying a Radius Application that contains a gateway resource and a container resource that share a name will result in an error being thrown during deployment. For example, when attempting to name a container and a gateway something like "foo", you'll get an error messaging similar to:
 
 ```
 Error - Type: IncludeError, Status: True, Reason: RootIncludesRoot, Message: root httpproxy cannot include another root httpproxy

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -38,6 +38,10 @@ See [app name constraints]({{< ref "resource-schema.md#common-values" >}}) for m
 
 Deploying a Radius Application that contains a gateway resource and a container resource that share a name will result in an error being thrown during the deployment process.
 
+```
+Error - Type: IncludeError, Status: True, Reason: RootIncludesRoot, Message: root httpproxy cannot include another root httpproxy
+```
+
 As a workaround make sure to use distinct names for both containers and gateways.
 
 ## rad CLI


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added a section in the limitations page for gateway resource naming conventions.

## Issue reference
Doc issue: https://github.com/radius-project/docs/issues/1038
Bug: https://github.com/radius-project/radius/issues/7149
