### PR TITLE
Add GH action to close stale PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes PRs that have had no activity for 90 days.
+#
+# For more information, see:
+# https://github.com/actions/stale
+name: Close stale pull requests
+
+on:
+  schedule:
+  - cron: '0 18 * * *' # Run the workflow every day at 6PM UTC (10AM PST).
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has been inactive for 90 days. Remove stale label or comment or this PR will be closed in 7 days.'
+        stale-pr-label: 'stale'
+        days-before-pr-stale: 90 # 3 months
+        days-before-pr-close: 7
+        days-before-issue-stale: -1
+        days-before-issue-close: -1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,7 @@ $ git commit -s -m 'This is my commit message'
 ```
 
 Visual Studio Code has a setting, `git.alwaysSignOff` to automatically add a Signed-off-by line to commit messages. Search for "sign-off" in VS Code settings to find it and enable it.
+
+## Inactive Pull Requests
+
+Pull requests that have been inactive for 90 days will be marked with a stale label. They will automatically be closed after a subsequent 7 days of inactivity. This timeframe may be adjusted in the future based on project needs.


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

To declutter the PR queue and ensure that active contributions receive attention, enabling https://github.com/actions/stale github action to automatically close stale PRs after 90 days of inactivity, with a notification period of 7 days.

This will provide contributors with a reasonable window to address any outstanding feedback or issues before the PR is automatically closed. We can adjust this timeframe in the future based on the feedback and learnings. We can also consider PRs labeled with certain labels to be excluded from this workflow if we see the need for this in the future: https://github.com/actions/stale?tab=readme-ov-file#exempt-pr-labels.

## Issue reference

Fixes: https://github.com/radius-project/radius/issues/7151