### PR TITLE
Update list of resource with a reference to portable resource page

### DIFF
--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref "/guides/author-apps/portable-resources/overview" >}}).
+Recipes support all of the available portable resources listed [here]({{< ref /guides/author-apps/portable-resources/overview >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref /guides/author-apps/portable-resources/overview >}}).
+Recipes support all of the available portable resources listed [here]({{< ref "/guides/author-apps/portable-resources/overview" >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref "/guides/author-apps/portable-resources/overview/#available-resources" >}}).
+Recipes support all of the available portable resources listed [here]({{< ref "/guides/author-apps/portable-resources/overview" >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref author-apps/portable-resources/overview/#available-resources >}}).
+Recipes support all of the available portable resources listed [here]({{< ref guides/author-apps/portable-resources/overview/#available-resources >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref guides/author-apps/portable-resources/overview/#available-resources >}}).
+Recipes support all of the available portable resources listed [here]({{< ref /guides/author-apps/portable-resources/overview/#available-resources >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,18 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes currently support the following resources. Support for additional resources is actively being worked on.
-
-| Supported resources |
-|---------------------|
-| [`Applications.Datastores/redisCaches`]({{< ref redis >}}) |
-| [`Applications.Datastores/mongoDatabases`]({{< ref mongodb >}}) |
-| [`Applications.Datastores/sqlDatabases`]({{< ref microsoft-sql >}}) |
-| [`Applications.Messaging/rabbitmqQueues`]({{< ref rabbitmq >}}) |
-| [`Applications.Dapr/stateStores`]({{< ref dapr-statestore >}}) |
-| [`Applications.Dapr/pubSubBrokers`]({{< ref dapr-pubsub >}}) |
-| [`Applications.Dapr/secretStores`]({{< ref dapr-secretstore >}}) |
-| [`Applications.Core/extenders`]({{< ref extender >}}) |
+Recipes support all of the available portable resources listed [here]({{< ref author-apps/portable-resources/overview/#available-resources >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref /guides/author-apps/portable-resources/overview#available-resources >}}).
+Recipes support all of the available portable resources listed [here]({{< ref "/guides/author-apps/portable-resources/overview/#available-resources" >}}).
 
 ## Infrastructure linking
 

--- a/docs/content/guides/recipes/overview/index.md
+++ b/docs/content/guides/recipes/overview/index.md
@@ -51,7 +51,7 @@ It's easy to author and register your own Recipes which define how to deploy and
 
 ## Supported resources
 
-Recipes support all of the available portable resources listed [here]({{< ref /guides/author-apps/portable-resources/overview/#available-resources >}}).
+Recipes support all of the available portable resources listed [here]({{< ref /guides/author-apps/portable-resources/overview#available-resources >}}).
 
 ## Infrastructure linking
 


### PR DESCRIPTION
## Description

Instead of replicating the list of available portable resources in multiple, add a reference to the portable resource page.

## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
