### PR TITLE
Add release version number to navbar

### DIFF
--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -53,7 +53,7 @@ VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
 awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"edge\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
-# In docs/config.toml, change version to VERSION instead of latest
+# In docs/config.toml, change version to VERSION instead of latest or older version
 VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
 awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -55,8 +55,7 @@ mv docs/config.toml.tmp docs/config.toml
 
 # In docs/config.toml, change version to CHANNEL_VERSION instead of latest or older version
 DOC_VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
-awk -v REPLACEMENT="${DOC_VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
-mv docs/config.toml.tmp docs/config.toml
+sed -i.bak -E "s/^( *)[ \t]*version = \"(latest|v.*)\"/\1${DOC_VERSION_STRING_REPLACEMENT}/" docs/config.toml
 
 # In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge
 GITHUB_BRANCH_STRING_REPLACEMENT="github_branch = \"${CHANNEL_VERSION}\""

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -16,7 +16,7 @@
 
 set -xe
 
-VERSION_NUMBER=$1 # (e.g. 0.1.0)
+VERSION_NUMBER='0.33'
 REPOSITORY="docs"
 
 if [[ -z "$VERSION_NUMBER" ]]; then
@@ -55,7 +55,7 @@ mv docs/config.toml.tmp docs/config.toml
 
 # In docs/config.toml, change version to VERSION instead of latest
 VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
-awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"latest\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "latest"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
 # In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -53,9 +53,9 @@ VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
 awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"edge\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
-# In docs/config.toml, change version to VERSION instead of latest or older version
-VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
-awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+# In docs/config.toml, change version to CHANNEL_VERSION instead of latest or older version
+DOC_VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
+awk -v REPLACEMENT="${DOC_VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
 # In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -16,7 +16,7 @@
 
 set -xe
 
-VERSION_NUMBER='0.33'
+VERSION_NUMBER=$1 # (e.g. 0.1.0)
 REPOSITORY="docs"
 
 if [[ -z "$VERSION_NUMBER" ]]; then

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -55,7 +55,7 @@ mv docs/config.toml.tmp docs/config.toml
 
 # In docs/config.toml, change version to VERSION instead of latest
 VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
-awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "latest"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
 # In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -56,6 +56,8 @@ mv docs/config.toml.tmp docs/config.toml
 # In docs/config.toml, change version to CHANNEL_VERSION instead of latest or older version
 DOC_VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
 sed -i.bak -E "s/^( *)[ \t]*version = \"(latest|v.*)\"/\1${DOC_VERSION_STRING_REPLACEMENT}/" docs/config.toml
+# Delete the backup file
+rm docs/config.toml.bak
 
 # In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge
 GITHUB_BRANCH_STRING_REPLACEMENT="github_branch = \"${CHANNEL_VERSION}\""

--- a/.github/scripts/release-docs.sh
+++ b/.github/scripts/release-docs.sh
@@ -53,6 +53,11 @@ VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
 awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"edge\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
 mv docs/config.toml.tmp docs/config.toml
 
+# In docs/config.toml, change version to VERSION instead of latest
+VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
+awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"latest\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
+mv docs/config.toml.tmp docs/config.toml
+
 # In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge
 GITHUB_BRANCH_STRING_REPLACEMENT="github_branch = \"${CHANNEL_VERSION}\""
 awk -v REPLACEMENT="${GITHUB_BRANCH_STRING_REPLACEMENT}" '{gsub(/github_branch = \"edge\"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -87,7 +87,7 @@ version_menu = "Releases"
   url = "https://edge.docs.radapp.io"
 
 [[params.versions]]
-  version = "v0.31"
+ version = "v0.31"
  url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -87,7 +87,7 @@ version_menu = "Releases"
   url = "https://edge.docs.radapp.io"
 
 [[params.versions]]
-version = "v0.31"
+  version = "v0.31"
   url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -87,8 +87,8 @@ version_menu = "Releases"
   url = "https://edge.docs.radapp.io"
 
 [[params.versions]]
- version = "v0.31"
- url = "https://docs.radapp.io"
+  version = "v0.31"
+  url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html
 [markup]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -88,7 +88,7 @@ version_menu = "Releases"
 
 [[params.versions]]
   version = "v0.31"
-  url = "https://docs.radapp.io"
+ url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html
 [markup]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -87,7 +87,7 @@ version_menu = "Releases"
   url = "https://edge.docs.radapp.io"
 
 [[params.versions]]
-  version = "latest"
+version = "v0.31"
   url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -87,7 +87,7 @@ version_menu = "Releases"
   url = "https://edge.docs.radapp.io"
 
 [[params.versions]]
-  version = "v0.31"
+  version = "latest"
   url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -87,7 +87,7 @@ version_menu = "Releases"
   url = "https://edge.docs.radapp.io"
 
 [[params.versions]]
-  version = "latest"
+  version = "v0.31"
   url = "https://docs.radapp.io"
 
 # Markdown Engine - Allow inline html


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Currently we display `latest` as the version label to users when accessing the navigation bar:

![Screenshot 2024-03-13 at 11 34 24 AM](https://github.com/radius-project/docs/assets/83607984/66e5eedd-0803-48ef-8d34-edd6228577f2)

This PR changes that to an actual version number so users are also more aware of the Radius release and exactly what version of docs they are accessing.

![Screenshot 2024-03-13 at 11 34 11 AM](https://github.com/radius-project/docs/assets/83607984/e0e139c8-8f48-40cb-8fd9-76ac00b04c8c)

## Issue reference

#556 

## Testing

I ran a shell script locally on a copy of the config.toml file the only lines changed are the chart_version param and version param

For a more specific call out the line:

```
awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' docs/config.toml > docs/config.toml.tmp
```
Looks for a line that contains `version = "latest"` or `version = "v..."`  while accepting white spaces or tabs but not params such as `tag_version` which would be caught without the strict expression

The shell script modifications i made:

```
VERSION_NUMBER='0.33.3'

# VERSION is the version number prefixed by 'v' (e.g. v0.1.0)
VERSION="v${VERSION_NUMBER}"

# CHANNEL is the major and minor version of the VERSION_NUMBER (e.g. 0.1)
CHANNEL="$(echo $VERSION_NUMBER | cut -d '.' -f 1,2)"

# CHANNEL_VERSION is the version with the 'v' prefix (e.g. v0.1)
CHANNEL_VERSION="v${CHANNEL}"

echo "Version number: ${VERSION_NUMBER}"
echo "Version: ${VERSION}"
echo "Channel: ${CHANNEL}"
echo "Channel version: ${CHANNEL_VERSION}"

# In docs/config.toml, change baseURL to https://docs.radapp.io/ instead of https://edge.docs.radapp.io/
awk '{gsub(/baseURL = \"https:\/\/edge\.docs\.radapp.io\/\"/,"baseURL = \"https:\/\/docs.radapp.io\/\""); print}' config.toml > config.toml.tmp
mv config.toml.tmp config.toml

# In docs/config.toml, change version to VERSION instead of edge
VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/version = \"edge\"/, REPLACEMENT); print}' config.toml > config.toml.tmp
mv config.toml.tmp config.toml

# In docs/config.toml, change version to VERSION instead of latest or older version
VERSION_STRING_REPLACEMENT="version = \"${CHANNEL_VERSION}\""
awk -v REPLACEMENT="${VERSION_STRING_REPLACEMENT}" '{gsub(/^[ \t]*version = "(latest|v.*)"/, REPLACEMENT); print}' config.toml > config.toml.tmp
mv config.toml.tmp config.toml

# In docs/config.toml, change github_branch to CHANNEL_VERSION instead of edge
GITHUB_BRANCH_STRING_REPLACEMENT="github_branch = \"${CHANNEL_VERSION}\""
awk -v REPLACEMENT="${GITHUB_BRANCH_STRING_REPLACEMENT}" '{gsub(/github_branch = \"edge\"/, REPLACEMENT); print}' config.toml > config.toml.tmp
mv config.toml.tmp config.toml

# In docs/config.toml, change chart_version (Helm chart) to VERSION_NUMBER
CHART_VERSION_STRING_REPLACEMENT="chart_version = \"${VERSION_NUMBER}\""
awk -v REPLACEMENT="${CHART_VERSION_STRING_REPLACEMENT}" '{gsub(/chart_version = \"[^\n]+\"/, REPLACEMENT); print}' config.toml > config.toml.tmp
mv config.toml.tmp config.toml
```

The config.toml file result
```
baseURL = "https://docs.radapp.io/"
languageCode = "en-us"
title = "Radius Docs"
theme =  "docsy"

disableFastRender = true

# Ignore sample code
ignoreFiles = ["/code/*"]

# Google Analytics
[services.googleAnalytics]
id = "G-9JR8B6TPF9"

enableGitInfo = true

# Mounts
[module]
  [[module.mounts]]
    source = "content"
    target = "content"
  [[module.mounts]]
    source = "shared-content"
    target = "content"
  [[module.mounts]]
    source = "static"
    target = "static"
  [[module.mounts]]
    source = "layouts"
    target = "layouts"
  [[module.mounts]]
    source = "data"
    target = "data"
  [[module.mounts]]
    source = "assets"
    target = "assets"
  [[module.mounts]]
    source = "archetypes"
    target = "archetypes"

# Taxonomies
[taxonomies]
category = "categories"
tag = "tags"

# Top Nav Bar
[[menu.main]]
    name = "Home"
    weight = 10
    url = "https://radapp.io"
    pre = "<i class='fas fa-home'></i>"
[[menu.main]]
    name = "Blog"
    weight = 20
    url = "https://blog.radapp.io"
    pre = "<i class='fas fa-blog'></i>"
[[menu.main]]
    name = "GitHub"
    weight = 40
    url = "https://github.com/radius-project"
    pre = "<i class='fab fa-github'></i>"
[[menu.main]]
    name = "Discord"
    weight = 90
    url = "https://aka.ms/Radius/Discord"
    pre = "<i class='fab fa-discord'></i>"

[params]
copyright = "Radius"
version = "v0.33"
tag_version = "latest"
chart_version = "0.33.3"

# Algolia Search
algolia_docsearch = true

# GitHub Information
github_repo = "https://github.com/radius-project/docs"
github_subdir = "docs"
github_branch = "v0.31"
github_project_repo = "https://github.com/radius-project/radius"

# Versioning
version_menu = "Releases"
[[params.versions]]
  version = "edge (preview)"
  url = "https://edge.docs.radapp.io"

[[params.versions]]
version = "v0.33"
  url = "https://docs.radapp.io"

# Markdown Engine - Allow inline html
[markup]
  [markup.goldmark]
    [markup.goldmark.renderer]
      unsafe = true

# UI Customization
[params.ui]
sidebar_menu_compact = true
sidebar_search_disable = true
sidebar_menu_foldable = true
sidebar_menu_truncate = 500
ul_show = 1
navbar_logo = true

[params.ui.feedback]
enable = true
yes = '<b>Glad to hear it!</b> Please feel free to <a href="https://github.com/radius-project/radius">star our repo</a> and join our <a href="https://aka.ms/radius/discord">Discord server</a> to stay up to date with the project.'
no = '<b>Sorry to hear that.</b> If you would like to also contribute a suggestion visit <a href="https://github.com/radius-project/docs/issues/new/choose"> and tell us how we can improve</a>.'
```
