### PR TITLE
Fix wrong kubernetes label in kubernetes interop docs

### DIFF
--- a/docs/content/tutorials/tutorial-add-radius/index.md
+++ b/docs/content/tutorials/tutorial-add-radius/index.md
@@ -151,7 +151,7 @@ Step 2: Deploy and test the existing Guestbook application using `kubectl`
 
 You will now add Radius to the Guestbook application's Kubernetes deployment manifests by making edits to the YAML files in the `deploy` directory. 
 
-1. In each of the YAML files that contain a manifest for `Kind: Deployment`, add the `annotations` property to `metadata`, and then add the `rad.app/enabled: 'true'` annotation. Note that the `'true'` must be surrounded in quotes.
+1. In each of the YAML files that contain a manifest for `Kind: Deployment`, add the `annotations` property to `metadata`, and then add the `radapp.io/enabled: 'true'` annotation. Note that the `'true'` must be surrounded in quotes.
 
    ```yaml
    ...
@@ -179,7 +179,7 @@ You will now add Radius to the Guestbook application's Kubernetes deployment man
    metadata:
       name: frontend
       annotations:
-         rad.app/enabled: 'true'
+         radapp.io/enabled: 'true'
    spec:
    selector:
       matchLabels:


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->

## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
