### PR TITLE
Update workflows to use correct environments

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -22,7 +22,8 @@ jobs:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == 'edge' && 'edge' || 'latest' }}
+      # If a PR into edge, use 'edge'. If a PR into anywhere else, use 'latest'. If a push, use the branch name.
+      name: ${{ github.event_name == 'pull_request' && (github.base_ref == 'edge' && 'edge' || 'latest') || github.ref_name }}
     env:
       GOVER: '^1.17'
       TUTORIAL_PATH: './docs/content/user-guides/tutorials/'
@@ -87,6 +88,7 @@ jobs:
     needs: ['build']
     runs-on: ubuntu-latest
     environment:
+      # If push to edge, use 'edge'. If push to anywhere else, use 'latest'.
       name: ${{ github.ref_name == 'edge' && 'edge' || 'latest' }}
       url: ${{ github.ref_name == 'edge' && 'https://edge.docs.radapp.io' || 'https://docs.radapp.io' }}
     steps:
@@ -117,8 +119,10 @@ jobs:
     needs: ['build']
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == 'edge' && 'edge' || 'latest' }}
-      url: ${{ github.ref_name == 'edge' && 'https://edge.docs.radapp.io' || 'https://docs.radapp.io' }}
+      # If a PR into edge, use 'edge'. If a PR into anywhere else, use 'latest'. If a push, use the branch name.
+      name: ${{ github.event_name == 'pull_request' && (github.base_ref == 'edge' && 'edge' || 'latest') || github.ref_name }}
+      # If a push to edge, use the edge URL. If a push to anywhere else, use the latest URL. If a PR, blank.
+      url: ${{ github.event_name == 'pull_request' && '' || (github.ref_name == 'edge' && 'https://edge.docs.radapp.io' || 'https://docs.radapp.io') }}
     steps:
       - name: Download Hugo artifacts
         uses: actions/download-artifact@v3
@@ -137,23 +141,12 @@ jobs:
           output_location: ""
           skip_app_build: true
 
-  test:
-    name: Test GitHub variable names
-    runs-on: ubuntu-latest
-    steps:
-       - name: Print GitHub Contexts
-         run: |
-          echo ${{ github.event_name }}
-          echo ${{ github.base_ref }}
-          echo ${{ github.ref }}
-          echo ${{ github.ref_name }}
-          echo ${{ github.head_ref }}
-
   close_pr_site:
     name: Close PR Staging Site
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     environment:
+      # If a PR into edge, use 'edge'. If a PR into anywhere else, use 'latest'.
       name: ${{ github.base_ref == 'edge' && 'edge' || 'latest' }}
       url:  ${{ github.base_ref == 'edge' && 'https://edge.docs.radapp.io' || 'https://docs.radapp.io' }}
     steps:
@@ -171,6 +164,7 @@ jobs:
     needs: ['build', 'deploy']
     runs-on: ubuntu-latest
     environment:
+      # If push to edge, use 'edge'. If push to anywhere else, use 'latest'.
       name: ${{ github.ref_name == 'edge' && 'edge' || 'latest' }}
     env:
       ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_API_APPID }}

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -137,13 +137,25 @@ jobs:
           output_location: ""
           skip_app_build: true
 
+  test:
+    name: Test GitHub variable names
+    runs-on: ubuntu-latest
+    steps:
+       - name: Print GitHub Contexts
+         run: |
+          echo ${{ github.event_name }}
+          echo ${{ github.base_ref }}
+          echo ${{ github.ref }}
+          echo ${{ github.ref_name }}
+          echo ${{ github.head_ref }}
+
   close_pr_site:
     name: Close PR Staging Site
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name == 'edge' && 'edge' || 'latest' }}
-      url: ${{ github.ref_name == 'edge' && 'https://edge.docs.radapp.io' || 'https://docs.radapp.io' }}
+      name: ${{ github.base_ref == 'edge' && 'edge' || 'latest' }}
+      url:  ${{ github.base_ref == 'edge' && 'https://edge.docs.radapp.io' || 'https://docs.radapp.io' }}
     steps:
       - name: Close Pull Request
         id: closepullrequest


### PR DESCRIPTION
This PR fixes a bug where PRs into the `edge` branch use the wrong GitHub environment which causes staging sites to be created and not cleaned up in `latest`.