### PR TITLE
Rename `rad app connections` to `rad app graph`

### DIFF
--- a/docs/content/guides/author-apps/containers/howto-connect-dependencies/index.md
+++ b/docs/content/guides/author-apps/containers/howto-connect-dependencies/index.md
@@ -51,7 +51,7 @@ Connections from a container to a resource result in environment variables for c
 Radius Connections are more than just environment variables and configuration. You can also access the "application graph" and understand the connections within your application with the following command:
 
 ```bash
-rad app connections -a demo
+rad app graph -a demo
 ```
 
 You should see the following output, detailing the connections between the `demo` container and the `db` Redis cache, along with information about the underlying Kubernetes resources running the app:


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
This PR renames `rad app connections` to `rad app graph` in one of the how-to's
<!--Please explain the changes you've made-->

## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
