### PR TITLE
Remove Limitation for terraform recipe show command

### DIFF
--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -93,10 +93,6 @@ output values object = {
 }
 ```
 
-### Terraform private registries
-
-Currently users cannot run `rad recipe show` on Radius Recipes registered inside of private git registries and will experience an error in the CLI.
-
 ## Bicep & Deployment Engine
 
 ### Currently using a forked version of Bicep


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There was an issue with `rad recipe show` command when using terraform recipes stored in a private source so we added a limitation to let the users know its expected. Now its fixed as part of https://github.com/radius-project/radius/issues/7267, so removing it.

## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: https://github.com/radius-project/radius/issues/7267
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
