### PR TITLE
fix dead links in contribution guide

### DIFF
--- a/docs/content/contributing/overview/index.md
+++ b/docs/content/contributing/overview/index.md
@@ -29,8 +29,8 @@ Check out the following table to learn where and how you can contribute:
 
 | Repository | Description | Contribution guides |
 |------------|-------------|---------------------|
-| **Radius** | Main repository that contains source code for [`rad` CLI]((https://github.com/radius-project/radius/blob/main/docs/contributing/contributing-code/contributing-code-cli/running-rad-cli.md)), [control plane]((https://github.com/radius-project/radius/blob/main/docs/contributing/contributing-code/contributing-code-control-plane/README.md)) and other components of Radius | [radius-project/radius](https://github.com/radius-project/radius/blob/main/CONTRIBUTING.md)|
 | **Docs** | Documentation for Radius | [radius-project/docs]({{< ref contributing-docs>}})|
-| **Recipes** | Commonly used [Recipe](https://docs.radapp.io/recipes) templates for Radius Environments | [radius-project/recipes](https://github.com/radius-project/recipes/blob/main/CONTRIBUTING.md) |(https://github.com/radius-project/recipes/blob/main/CONTRIBUTING.md) |
+| **Radius** | Main repository that contains source code for [`rad` CLI](https://github.com/radius-project/radius/blob/main/docs/contributing/contributing-code/contributing-code-cli/README.md), [control plane](https://github.com/radius-project/radius/blob/main/docs/contributing/contributing-code/contributing-code-control-plane/README.md) and other components of Radius | [radius-project/radius](https://github.com/radius-project/radius/blob/main/CONTRIBUTING.md)|
+| **Recipes** | Commonly used [Recipe]({{< ref "guides/recipes/overview">}}) templates for Radius Environments | [radius-project/recipes](https://github.com/radius-project/recipes/blob/main/CONTRIBUTING.md) |
 | **Dashboard** | The frontend experience for Radius |[radius-project/dashboard](https://github.com/radius-project/dashboard/blob/main/CONTRIBUTING.md) |
 | **Bicep** |  Temporary fork of the [Bicep repo](https://github.com/azure/bicep) used to inject the Radius types into the Bicep language. Contains both the Bicep CLI and the Bicep VS Code extension. | [radius-project/bicep](https://github.com/radius-project/bicep/blob/radius-compiler/CONTRIBUTING.md) |


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

There are a few dead links in the contribution guide that this fixes.

<!--Please explain the changes you've made-->

## Issue reference

n/a - reported to me over direct message

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
