### PR TITLE
Remove port in provider config HowTo Custom Provider

### DIFF
--- a/docs/content/guides/recipes/terraform/howto-custom-provider/snippets/env.bicep
+++ b/docs/content/guides/recipes/terraform/howto-custom-provider/snippets/env.bicep
@@ -43,7 +43,6 @@ resource env 'Applications.Core/environments@2023-10-01-preview' = {
         providers: {
           postgresql: [ {
               sslmode: 'disable'
-              port: 5432
               secrets: {
                 username: {
                   source: pgsSecretStore.id


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Port is passed in as an environment variable in this example. The change is to update one of the bicep files which has port both in provider config and as environment variable. Although the bicep still deploys successfully, we're removing this from the provider config as it's not needed.
