### PR TITLE
Update k3d cluster create example

### DIFF
--- a/docs/content/guides/operations/kubernetes/overview/index.md
+++ b/docs/content/guides/operations/kubernetes/overview/index.md
@@ -86,7 +86,7 @@ softwareupdate --install-rosetta --agree-to-license
 Next, use the following commands to create a new cluster and install the Radius control plane, along with a new environment:
 
 ```bash
-k3d cluster create -p "8081:80@loadbalancer" --k3s-arg "--disable=traefik@server:0"
+k3d cluster create -p "8081:80@loadbalancer" --k3s-arg "--disable=traefik@server:*" --k3s-arg "--disable=servicelb@server:*"
 rad install kubernetes --set rp.publicEndpointOverride=localhost:8081
 rad init
 ```


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This PR updates the recommended command to use when creating a k3d cluster by adding a parameter to the `k3d cluster create` command to disable the default load balancer. The default load balancer was conflicting with the load balancer deployed by Radius. See the issue reference linked below for details.

Note: `traefik@server:0` was changed to `traefik@server:*` to indicate that all instances should be affected, not just the one at index zero.

## Issue reference

Fixes: https://github.com/radius-project/radius/issues/7637