### PR TITLE
Remove codespaces and add link to k3d config 

### DIFF
--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -15,13 +15,13 @@ This guide will show you how to quickly get started with Radius. You'll walk thr
 **Estimated time to complete: 10 min**
 
 {{< image src="diagram.png" alt="Diagram of the application and its resources" width="500px" >}}
-//commenting until we enable free minutes to try Codepaces
+
+<! commenting until we enable free minutes to try Codepaces
 {{< alert title="🚀 Run in a <b>free</b> GitHub Codespace" color="primary" >}}
 The Radius getting-started guide can be [run **for free** in a GitHub Codespace](https://github.blog/changelog/2022-11-09-codespaces-for-free-and-pro-accounts/). Visit the following link to get started in seconds:
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/radius-project/samples)
-{{< /alert >}}
-//
+{{< /alert >}} >
 
 ## 1. Have your Kubernetes cluster handy
 

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -26,7 +26,7 @@ The Radius getting-started guide can be [run **for free** in a GitHub Codespace]
 ## 1. Have your Kubernetes cluster handy
 
 Radius runs inside [Kubernetes]({{< ref "guides/operations/kubernetes" >}}). However you run Kubernetes, get a cluster ready.
-> *If you don't have a preferred way to create Kubernetes clusters, you could try using [k3d](https://k3d.io/), which runs a minimal Kubernetes distribution in Docker. Make sure to apply the [recommended configuration]({{< ref "guides/operations/kubernetes/overview##supported-kubernetes-clusters" >}})*
+> *If you don't have a preferred way to create Kubernetes clusters, you could try using [k3d](https://k3d.io/), which runs a minimal Kubernetes distribution in Docker. Make sure to apply the [recommended configuration]({{< ref "guides/operations/kubernetes/overview##supported-kubernetes-clusters" >}}).*
 
 Ensure your cluster is set as your current context:
 

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -19,7 +19,7 @@ This guide will show you how to quickly get started with Radius. You'll walk thr
 ## 1. Have your Kubernetes cluster handy
 
 Radius runs inside [Kubernetes]({{< ref "guides/operations/kubernetes" >}}). However you run Kubernetes, get a cluster ready.
-> *If you don't have a preferred way to create Kubernetes clusters, you could try using k3d with the recommended [configuration]({{< ref "guides/operations/kubernetes/overview##supported-kubernetes-clusters" >}}), which runs a minimal Kubernetes distribution in Docker.*
+> *If you don't have a preferred way to create Kubernetes clusters, you could try using [k3d](https://k3d.io/), which runs a minimal Kubernetes distribution in Docker. Make sure to apply the [recommended configuration]({{< ref "guides/operations/kubernetes/overview##supported-kubernetes-clusters" >}})*
 
 Ensure your cluster is set as your current context:
 

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -15,6 +15,13 @@ This guide will show you how to quickly get started with Radius. You'll walk thr
 **Estimated time to complete: 10 min**
 
 {{< image src="diagram.png" alt="Diagram of the application and its resources" width="500px" >}}
+//commenting until we enable free minutes to try Codepaces
+{{< alert title="🚀 Run in a <b>free</b> GitHub Codespace" color="primary" >}}
+The Radius getting-started guide can be [run **for free** in a GitHub Codespace](https://github.blog/changelog/2022-11-09-codespaces-for-free-and-pro-accounts/). Visit the following link to get started in seconds:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/radius-project/samples)
+{{< /alert >}}
+//
 
 ## 1. Have your Kubernetes cluster handy
 

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -16,16 +16,10 @@ This guide will show you how to quickly get started with Radius. You'll walk thr
 
 {{< image src="diagram.png" alt="Diagram of the application and its resources" width="500px" >}}
 
-{{< alert title="🚀 Run in a <b>free</b> GitHub Codespace" color="primary" >}}
-The Radius getting-started guide can be [run **for free** in a GitHub Codespace](https://github.blog/changelog/2022-11-09-codespaces-for-free-and-pro-accounts/). Visit the following link to get started in seconds:
-
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/radius-project/samples)
-{{< /alert >}}
-
 ## 1. Have your Kubernetes cluster handy
 
 Radius runs inside [Kubernetes]({{< ref "guides/operations/kubernetes" >}}). However you run Kubernetes, get a cluster ready.
-> *If you don't have a preferred way to create Kubernetes clusters, you could try using [k3d](https://k3d.io/), which runs a minimal Kubernetes distribution in Docker.*
+> *If you don't have a preferred way to create Kubernetes clusters, you could try using k3d with the recommended [configuration]({{< ref "guides/operations/kubernetes/overview##supported-kubernetes-clusters" >}}), which runs a minimal Kubernetes distribution in Docker.*
 
 Ensure your cluster is set as your current context:
 

--- a/docs/content/getting-started/index.md
+++ b/docs/content/getting-started/index.md
@@ -16,12 +16,12 @@ This guide will show you how to quickly get started with Radius. You'll walk thr
 
 {{< image src="diagram.png" alt="Diagram of the application and its resources" width="500px" >}}
 
-<! commenting until we enable free minutes to try Codepaces
+<!-- commenting until we enable free minutes to try Codepaces
 {{< alert title="🚀 Run in a <b>free</b> GitHub Codespace" color="primary" >}}
 The Radius getting-started guide can be [run **for free** in a GitHub Codespace](https://github.blog/changelog/2022-11-09-codespaces-for-free-and-pro-accounts/). Visit the following link to get started in seconds:
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/radius-project/samples)
-{{< /alert >}} >
+{{< /alert >}}-->
 
 ## 1. Have your Kubernetes cluster handy
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

<!--Please explain the changes you've made-->
This PR removed Codespaces as it is disabled for the project. We are working with the CNCF team to get it re-enabled. Also ads link to the k3d cluster config 

## Issue reference
Fixes: https://github.com/radius-project/docs/issues/1171
<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
