### PR TITLE
Add Application.Dapr/Bindings related docs

### DIFF
--- a/docs/content/reference/api/applications.dapr/api-bindings.md
+++ b/docs/content/reference/api/applications.dapr/api-bindings.md
@@ -1,0 +1,9 @@
+---
+type: api
+title: "Applications.Dapr/bindings API reference"
+linkTitle: "bindings"
+description: "Detailed reference documentation on the Applications.Dapr/bindings API"
+slug: "bindings"
+---
+
+{{< redoc "swagger/specification/applications/resource-manager/Applications.Dapr/preview/2023-10-01-preview/openapi.json" >}}

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-binding/index.md
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-binding/index.md
@@ -1,0 +1,93 @@
+---
+type: docs
+title: "Dapr Binding resource"
+linkTitle: "Binding"
+description: "Learn how to use Dapr Binding in Radius"
+weight: 300
+slug: "binding"
+---
+
+## Overview
+
+An `Applications.Dapr/bindings` resource represents a [Dapr binding](https://docs.dapr.io/developing-applications/building-blocks/bindings/bindings-overview/).
+
+## Resource format
+
+{{< tabs Recipe Manual >}}
+
+{{< codetab >}}
+
+{{< rad file="snippets/dapr-binding-recipe.bicep" embed=true marker="//SAMPLE" >}}
+
+{{< /codetab >}}
+
+{{< codetab >}}
+
+{{< rad file="snippets/dapr-binding-manual.bicep" embed=true marker="//SAMPLE" >}}
+
+{{< /codetab >}}
+
+{{< /tabs >}}
+
+### Top-level
+
+| Key  | Required | Description | Example |
+|------|:--------:|-------------|---------|
+| name | y | The name of the Binding. Names must contain at most 63 characters, contain only lowercase alphanumeric characters, '-', or '.', start with an alphanumeric character, and end with an alphanumeric character. | `my-config` |
+| location | y | The location of your resource. See [common values]({{< ref "resource-schema.md#common-values" >}}) for more information. | `global`
+| [properties](#properties) | y | Properties of the resource. | [See below](#properties)
+
+### Properties
+
+| Key  | Required | Description | Example |
+|------|:--------:|-------------|---------|
+| application | n | The ID of the application resource this resource belongs to. | `app.id`
+| [auth](#auth) | n | Authentication information for this component. | [See below](#auth)
+| environment | y | The ID of the environment resource this resource belongs to. | `env.id`
+| [resourceProvisioning](#resource-provisioning) | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. Defaults to 'recipe'. | `manual`
+| [recipe](#recipe) | n | Configuration for the Recipe which will deploy the backing infrastructure. | [See below](#recipe)
+| [resources](#resources) | n | An array of resources which underlay this resource. For example, an Azure Redis Cache ID if the Dapr Binding resource is leveraging Azure Redis Cache. | [See below](#resources)
+| type | n | The Dapr component type. Set only when resourceProvisioning is 'manual'. | `binding.cron` |
+| metadata | n | Metadata object for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-bindings/). Set only when resourceProvisioning is 'manual'. | `{ redisHost: 'localhost:6379' }` |
+| version | n | The version of the Dapr component. See [Dapr components](https://docs.dapr.io/reference/components-reference/supported-bindings/) for available versions. Set only when resourceProvisioning is 'manual'. | `v1` |
+| componentName | n | _(read-only)_ The name of the Dapr component that is generated and applied to the underlying system. Used by the Dapr SDKs or APIs to access the Dapr component. | `mybinding` |
+
+#### Auth
+| Property | Required | Description | Example(s) |
+|------|:--------:|-------------|---------|
+| secretStore | n | The name of the secret store to retrieve secrets from. | `secretstore.id` |
+
+#### Recipe
+
+| Property | Required | Description | Example(s) |
+|------|:--------:|-------------|---------|
+| name | n | Specifies the name of the Recipe that should be deployed. If not set, the name defaults to `default`. | `name: 'azure-prod'`
+| parameters | n | An object that contains a list of parameters to set on the Recipe. | `{ size: 'large' }`
+
+#### Resources
+
+| Property | Required | Description | Example(s) |
+|----------|:--------:|-------------|------------|
+| id | n | Resource ID of the supporting resource. | `account.id`
+
+## Resource provisioning
+
+### Provision with a Recipe
+
+[Recipes]({{< ref "guides/recipes/overview" >}}) automate infrastructure provisioning using approved templates.
+
+You can specify a Recipe name that is registered in the environment or omit the name and use the "default" Recipe.
+
+Parameters can also optionally be specified for the Recipe.
+
+### Provision manually
+
+If you want to manually manage your infrastructure provisioning outside of Recipes, you can set `resourceProvisioning` to `'manual'` and specify `type`, `metadata`, and `version` for the Dapr component. These values must match the schema of the intended [Dapr component](https://docs.dapr.io/reference/components-reference/supported-bindings/).
+
+## Environment variables for connections
+
+Other Radius resources, such as [containers]({{< ref "guides/author-apps/containers" >}}), may connect to a Dapr Binding resource via [connections]({{< ref "application-graph#connections-and-injected-values" >}}). When a connection to Dapr Binding named, for example, `myconnection` is declared, Radius injects values into environment variables that are then used to access the connected Dapr Binding resource:
+
+| Environment variable | Example(s) |
+|----------------------|------------|
+| CONNECTION_MYCONNECTION_COMPONENTNAME | `mybinding` |

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-manual.bicep
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-manual.bicep
@@ -1,0 +1,71 @@
+extension radius
+
+param magpieimage string
+param environment string
+param namespace string = 'default'
+param baseName string = 'dbd-manual'
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: baseName
+  properties: {
+    environment: environment
+  }
+}
+
+resource myapp 'Applications.Core/containers@2023-10-01-preview' = {
+  name: '${baseName}-ctnr'
+  properties: {
+    application: app.id
+    connections: {
+      daprbinding: {
+        source: binding.id
+      }
+    }
+    container: {
+      image: magpieimage
+      readinessProbe: {
+        kind: 'httpGet'
+        containerPort: 3000
+        path: '/healthz'
+      }
+    }
+    extensions: [
+      {
+        kind: 'daprSidecar'
+        appId: 'dbd-manual-ctnr'
+        appPort: 3000
+      }
+    ]
+  }
+}
+
+
+module redis '../../../../../../test/testrecipes/modules/redis-selfhost.bicep' = {
+  name: '${baseName}-redis-deployment'
+  params: {
+    name: '${baseName}-redis'
+    namespace: namespace
+    application: app.name
+  }
+}
+
+//SAMPLE
+resource binding 'Applications.Dapr/bindings@2023-10-01-preview' = {
+  name: 'outredis'
+  properties: {
+    application: app.id
+    environment: environment
+    resourceProvisioning: 'manual'
+    type: 'bindings.redis'
+    metadata: {
+      redisHost: {
+        value: '${redis.outputs.host}:${redis.outputs.port}'
+      }
+      redisPassword: {
+        value: ''
+      }
+    }
+    version: 'v1'
+  }
+}
+//SAMPLE

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-manual.bicep
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-manual.bicep
@@ -39,7 +39,6 @@ resource myapp 'Applications.Core/containers@2023-10-01-preview' = {
   }
 }
 
-
 module redis '../../../../../../test/testrecipes/modules/redis-selfhost.bicep' = {
   name: '${baseName}-redis-deployment'
   params: {

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-manual.bicep
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-manual.bicep
@@ -39,15 +39,6 @@ resource myapp 'Applications.Core/containers@2023-10-01-preview' = {
   }
 }
 
-module redis '../../../../../../test/testrecipes/modules/redis-selfhost.bicep' = {
-  name: '${baseName}-redis-deployment'
-  params: {
-    name: '${baseName}-redis'
-    namespace: namespace
-    application: app.name
-  }
-}
-
 //SAMPLE
 resource binding 'Applications.Dapr/bindings@2023-10-01-preview' = {
   name: 'outredis'
@@ -58,7 +49,7 @@ resource binding 'Applications.Dapr/bindings@2023-10-01-preview' = {
     type: 'bindings.redis'
     metadata: {
       redisHost: {
-        value: '${redis.outputs.host}:${redis.outputs.port}'
+        value: '<REDIS-URL>'
       }
       redisPassword: {
         value: ''

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-recipe.bicep
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-binding/snippets/dapr-binding-recipe.bicep
@@ -1,0 +1,29 @@
+extension radius
+
+@description('The ID of your Radius Environment. Automatically injected by the rad CLI.')
+param environment string
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: 'dapr-binding'
+  properties: {
+    environment: environment
+  }
+}
+
+//SAMPLE
+resource binding 'Applications.Dapr/bindings@2023-10-01-preview' = {
+  name: 'binding'
+  properties: {
+    environment: environment
+    application: app.id
+    recipe: {
+      // Name a specific recipe to use
+      name: 'smtp-server-binding'
+      // Set optional/required parameters (specific to the Recipe)
+      parameters: {
+        validateHtml: true
+      }
+    }
+  }
+}
+//SAMPLE

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-configurationStore/index.md
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-configurationStore/index.md
@@ -42,6 +42,7 @@ An `Applications.Dapr/configurationStores` resource represents a [Dapr configura
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
+| [auth](#auth) | n | Authentication information for this component. | [See below](#auth)
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | [resourceProvisioning](#resource-provisioning) | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. Defaults to 'recipe'. | `manual`
 | [recipe](#recipe) | n | Configuration for the Recipe which will deploy the backing infrastructure. | [See below](#recipe)
@@ -50,6 +51,11 @@ An `Applications.Dapr/configurationStores` resource represents a [Dapr configura
 | metadata | n | Metadata object for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-configuration-stores/). Set only when resourceProvisioning is 'manual'. | `{ redisHost: 'localhost:6379' }` |
 | version | n | The version of the Dapr component. See [Dapr components](https://docs.dapr.io/reference/components-reference/supported-configuration-stores/) for available versions. Set only when resourceProvisioning is 'manual'. | `v1` |
 | componentName | n | _(read-only)_ The name of the Dapr component that is generated and applied to the underlying system. Used by the Dapr SDKs or APIs to access the Dapr component. | `myconfig` |
+
+#### Auth
+| Property | Required | Description | Example(s) |
+|------|:--------:|-------------|---------|
+| secretStore | n | The name of the secret store to retrieve secrets from. | `secretstore.id` |
 
 #### Recipe
 

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-pubsub/index.md
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-pubsub/index.md
@@ -42,6 +42,7 @@ An `Applications.Dapr/pubSubBrokers` resource represents a [Dapr pub/sub](https:
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
+| [auth](#auth) | n | Authentication information for this component. | [See below](#auth)
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | [resourceProvisioning](#resource-provisioning) | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. Defaults to 'recipe'. | `manual`
 | [recipe](#recipe) | n | Configuration for the Recipe which will deploy the backing infrastructure. | [See below](#recipe)
@@ -50,6 +51,11 @@ An `Applications.Dapr/pubSubBrokers` resource represents a [Dapr pub/sub](https:
 | metadata | n | Metadata object for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-pubsub/). Set only when resourceProvisioning is 'manual'. | `{ brokers: { value: kafkaRoute.properties.url } }` |
 | version | n | The version of the Dapr component. See [Dapr components](https://docs.dapr.io/reference/components-reference/supported-pubsub/) for available versions. Set only when resourceProvisioning is 'manual'. | `v1` |
 | componentName | n | _(read-only)_ The name of the Dapr component that is generated and applied to the underlying system. Used by the Dapr SDKs or APIs to access the Dapr component. | `mypubsub` |
+
+#### Auth
+| Property | Required | Description | Example(s) |
+|------|:--------:|-------------|---------|
+| secretStore | n | The name of the secret store to retrieve secrets from. | `secretstore.id` |
 
 #### Recipe
 

--- a/docs/content/reference/resource-schema/dapr-schema/dapr-statestore/index.md
+++ b/docs/content/reference/resource-schema/dapr-schema/dapr-statestore/index.md
@@ -45,6 +45,7 @@ This resource will automatically create and deploy the Dapr component spec for t
 | Key  | Required | Description | Example |
 |------|:--------:|-------------|---------|
 | application | n | The ID of the application resource this resource belongs to. | `app.id`
+| [auth](#auth) | n | Authentication information for this component. | [See below](#auth)
 | environment | y | The ID of the environment resource this resource belongs to. | `env.id`
 | [resourceProvisioning](#resource-provisioning) | n | Specifies how the underlying service/resource is provisioned and managed. Options are to provision automatically via 'recipe' or provision manually via 'manual'. Selection determines which set of fields to additionally require. Defaults to 'recipe'. | `manual`
 | [recipe](#recipe) | n | Configuration for the Recipe which will deploy the backing infrastructure. | [See below](#recipe)
@@ -53,6 +54,11 @@ This resource will automatically create and deploy the Dapr component spec for t
 | metadata | n | Metadata for the Dapr component. Schema must match [Dapr component](https://docs.dapr.io/reference/components-reference/supported-state-stores/). Used when `resourceProvisioning` is set to `manual`. | `{ couchbaseURL: {value: 'https://*****' }` |
 | version | n | The version of the Dapr component. See [Dapr components](https://docs.dapr.io/reference/components-reference/supported-state-stores/) for available versions. Used when `resourceProvisioning` is set to `manual`. | `v1` |
 | componentName | n | _(read-only)_ The name of the Dapr component that is generated and applied to the underlying system. Used by the Dapr SDKs or APIs to access the Dapr component. | `mystatestore` |
+
+#### Auth
+| Property | Required | Description | Example(s) |
+|------|:--------:|-------------|---------|
+| secretStore | n | The name of the secret store to retrieve secrets from. | `secretstore.id` |
 
 #### Recipe
 


### PR DESCRIPTION
- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [NA] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [NA] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

## Description
Hey,

This PR adds some documentation on the Dapr Binding Building Block
It also adds the `auth` block for all compatible Dapr components, which was previously undocumented (my bad).

## Issue reference

Fixes: radius-project/radius#7960
