### PR TITLE
Update upmerge workflow to ignore config and body-end changes 

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -79,4 +79,4 @@ jobs:
         if: env.NO_CHANGES != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT}}
-        run: gh pr create --title "Upmerge to edge" --body "Upmerge to edge (kicked off by @${{ github.triggering_actor }})" --base edge --head $BRANCH_NAME
+        run: gh pr create --title "Upmerge to edge" --body "Upmerge to edge (kicked off by @${{ github.triggering_actor }})" --base edge --head $BRANCH_NAME --signoff

--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -62,15 +62,15 @@ jobs:
           export SOURCE_BRANCH=$(basename ${{ github.ref }})
           echo "Upmerging docs from $SOURCE_BRANCH to edge"
           git fetch origin $SOURCE_BRANCH
-          
-          git merge -m "Upmerge to edge" origin/$SOURCE_BRANCH
+          git merge --no-commit origin/$SOURCE_BRANCH
+          git checkout edge -- docs/config.toml docs/layouts/partials/hooks/body-end.html
+          git commit -m "Upmerge to edge"
           
           if git diff --quiet edge; then
               echo "No changes to merge from $SOURCE_BRANCH to edge"
               echo "NO_CHANGES=true" >> $GITHUB_ENV
           else
               echo "Pushing $BRANCH_NAME for PR to edge"
-              git reset HEAD docs/config.toml docs/layouts/partials/hooks/body-end.html
               git push --set-upstream origin $BRANCH_NAME
           fi
       
@@ -79,4 +79,4 @@ jobs:
         if: env.NO_CHANGES != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT}}
-        run: gh pr create --title "Upmerge to edge" --body "Upmerge to edge (kicked off by @${{ github.triggering_actor }})" --base edge --head $BRANCH_NAME --signoff
+        run: gh pr create --title "Upmerge to edge" --body "Upmerge to edge (kicked off by @${{ github.triggering_actor }})" --base edge --head $BRANCH_NAME


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

We ignore certain files in the upmerge workflow that shouldn't get overwritten in edge. This was previously broken because we weren't resetting to the changes on edge. Instead, we were resetting to the changes after the merge. 

Test run: https://github.com/sk593/radius-docs/actions/runs/11728935169/job/32673463501
Test branch with config/body-end changes: https://github.com/sk593/radius-docs/pull/3/files
Test PR opened from upmerge workflow (with no config/body-end changes): https://github.com/sk593/radius-docs/pull/2

## Issue reference

<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
