### PR TITLE
Adding a new limitation to call out typos in radius resource type

### DIFF
--- a/.github/config/en-custom.txt
+++ b/.github/config/en-custom.txt
@@ -1297,3 +1297,4 @@ configurationStores
 configurationstores
 Oras
 oras
+DeploymentTemplate

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -45,12 +45,12 @@ Error - Type: IncludeError, Status: True, Reason: RootIncludesRoot, Message: roo
 As a workaround make sure to use distinct names for both containers and gateways.
 
 ### Typos in Radius Resource Type Names
-Deploying a Radius Resources with a typo in the resource type will result in an error being thrown during deployment. For example, when `Application.Core/Extenders` is defined as `Application.Core/Extender` you will get an error messaging similar to:
+Deploying a Radius Resources with a typo in the resource type or an unsupported resource type will result in an Azure provider related error being thrown during deployment. For example, when `Application.Core/Extenders` is defined as `Application.Core/Extender` you will get an error messaging similar to:
 ```
 Azure deployment failed, please ensure you have configured an Azure provider with your Radius environment: https://docs.radapp.io/guides/operations/providers/azure-provider/
 ```
 
-As a workaround make sure to use correct resource type names while defining radius resources.
+We are working on making this error clearer. In the meantime, when you see this error please make sure to ensure that the resource type name is correctly specified while defining radius resources in your application/environment bicep file.
 
 ## rad CLI
 

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -44,6 +44,14 @@ Error - Type: IncludeError, Status: True, Reason: RootIncludesRoot, Message: roo
 
 As a workaround make sure to use distinct names for both containers and gateways.
 
+### Typos in Radius Resource Type Names
+Deploying a Radius Resources with a typo in the resource type will result in an error being thrown during deployment. For example, when `Application.Core/Extenders` is defined as `Application.Core/Extender` you will get an error messaging similar to:
+```
+Azure deployment failed, please ensure you have configured an Azure provider with your Radius environment: https://docs.radapp.io/guides/operations/providers/azure-provider/
+```
+
+As a workaround make sure to use correct resource type names while defining radius resources.
+
 ## rad CLI
 
 ### Application and resource names are lower-cased after deployment

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -44,12 +44,6 @@ Error - Type: IncludeError, Status: True, Reason: RootIncludesRoot, Message: roo
 
 As a workaround make sure to use distinct names for both containers and gateways.
 
-### Typos in Radius Resource Type Names
-Deploying a Radius Resources with a typo in the resource type will result in an error being thrown during deployment. For example, when `Application.Core/Extenders` is defined as `Application.Core/Extender` you will get an error messaging similar to: 
-```
-Azure deployment failed, please ensure you have configured an Azure provider with your Radius environment: https://docs.radapp.io/guides/operations/providers/azure-provider/
-```
-
 ## rad CLI
 
 ### Application and resource names are lower-cased after deployment

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -50,7 +50,7 @@ Deploying a Radius Resources with a typo in the resource type or an unsupported 
 Azure deployment failed, please ensure you have configured an Azure provider with your Radius environment: https://docs.radapp.io/guides/operations/providers/azure-provider/
 ```
 
-We are working on making this error clearer. In the meantime, when you see this error please make sure to ensure that the resource type name is correctly specified while defining radius resources in your application/environment bicep file.
+We are working on making this error clearer. In the meantime, when you see this error please ensure that the resource type name is correctly specified in your Radius Application or Environment Bicep file.
 
 ## rad CLI
 

--- a/docs/content/reference/limitations.md
+++ b/docs/content/reference/limitations.md
@@ -44,6 +44,12 @@ Error - Type: IncludeError, Status: True, Reason: RootIncludesRoot, Message: roo
 
 As a workaround make sure to use distinct names for both containers and gateways.
 
+### Typos in Radius Resource Type Names
+Deploying a Radius Resources with a typo in the resource type will result in an error being thrown during deployment. For example, when `Application.Core/Extenders` is defined as `Application.Core/Extender` you will get an error messaging similar to: 
+```
+Azure deployment failed, please ensure you have configured an Azure provider with your Radius environment: https://docs.radapp.io/guides/operations/providers/azure-provider/
+```
+
 ## rad CLI
 
 ### Application and resource names are lower-cased after deployment


### PR DESCRIPTION
Today if there is a typo is radius resource types, it throws an error similar to `Azure deployment failed, please ensure you have configured an Azure provider with your Radius environment: https://docs.radapp.io/guides/operations/providers/azure-provider/` adding it in the docs .