### PR TITLE
fix: misleading info regrading tf auth to a private git repo

### DIFF
--- a/docs/content/guides/recipes/terraform/howto-private-registry/index.md
+++ b/docs/content/guides/recipes/terraform/howto-private-registry/index.md
@@ -30,7 +30,7 @@ The PAT should have access to read the files inside the specific private reposit
 
 ## Step 2: Define a secret store resource
 
-Configure a [Radius Secret Store]({{< ref "/guides/author-apps/secrets/overview" >}}) with the personal access token or username + password you previously created, which has access to your private git repository. Define the namespace for the cluster that will contain your [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with the `resource` property. 
+Configure a [Radius Secret Store]({{< ref "/guides/author-apps/secrets/overview" >}}) with the username and personal access token (or password) you previously created. Both are required to access your private git repository. Define the namespace for the cluster that will contain your [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/) with the `resource` property. 
 
 > While this example shows a Radius-managed secret store where Radius creates the underlying secrets infrastructure, you can also bring your own existing secrets. Refer to the [secrets documentation]({{< ref "/guides/author-apps/secrets/overview" >}}) for more information.
 
@@ -38,7 +38,7 @@ Create a Bicep file `env.bicep`, import Radius, and  define your resource:
 
 {{< rad file="snippets/env.bicep" embed=true marker="//SECRETSTORE" >}}
 
-> The property `pat` is required and refers to your personal access token or password, while `username` is optional and refers to a username, if your git platform requires one.
+> Both properties `username` and `pat` are required. `username` refers to your username for the git platform, and `pat` refers to your personal access token or password.
 
 ## Step 3: Configure Terraform Recipe git authentication
 
@@ -59,7 +59,7 @@ Update your Environment with a Terraform Recipe, pointing to your private git re
 Deploy your new Radius Environment:
 
 ```
-rad deploy ./env.bicep -p pat=******
+rad deploy ./env.bicep -p user=<GIT-PLATFORM-USERNAME> -p pat=<GIT-PLATFORM-PAT>
 ```
 
 ## Done

--- a/docs/content/guides/recipes/terraform/howto-private-registry/snippets/env-complete.bicep
+++ b/docs/content/guides/recipes/terraform/howto-private-registry/snippets/env-complete.bicep
@@ -1,6 +1,9 @@
 //SECRETSTORE
 extension radius
 
+@description('Required value, refers to the username of the git platform')
+param user string
+
 @description('Required value, refers to the personal access token or password of the git platform')
 @secure()
 param pat string
@@ -11,6 +14,9 @@ resource secretStoreGit 'Applications.Core/secretStores@2023-10-01-preview' = {
     resource: 'my-secret-namespace/github'
     type: 'generic'
     data: {
+      username: {
+        value: user
+      }
       pat: {
         value: pat 
       }

--- a/docs/content/guides/recipes/terraform/howto-private-registry/snippets/env.bicep
+++ b/docs/content/guides/recipes/terraform/howto-private-registry/snippets/env.bicep
@@ -1,6 +1,9 @@
 //SECRETSTORE
 extension radius
 
+@description('Required value, refers to the username of the git platform')
+param user string
+
 @description('Required value, refers to the personal access token or password of the git platform')
 @secure()
 param pat string
@@ -11,6 +14,9 @@ resource secretStoreGit 'Applications.Core/secretStores@2023-10-01-preview' = {
     resource: 'my-secret-namespace/github'
     type: 'generic'
     data: {
+      username: {
+        value: user
+      }
       pat: {
         value: pat 
       }


### PR DESCRIPTION
This PR aims to fix misleading information presented in [How-To: Pull Terraform modules from private git repositories](https://edge.docs.radapp.io/guides/recipes/terraform/howto-private-registry/) section. Long story short the username and password(or PAT) are required to authenticate to private git repositories, otherwise the operators might encounter difficulties like those outlined in this [issue](https://github.com/radius-project/radius/issues/9929). This issue is also reported here: #1485

Fixes: #1485 