### PR TITLE
fix(ui): Adjust code snippet styling to prevent overflow issue

### DIFF
--- a/docs/assets/scss/_code.scss
+++ b/docs/assets/scss/_code.scss
@@ -33,6 +33,15 @@
             padding: 1rem;
             border-radius: 10px;
         }
+
+        table td:nth-child(2) {
+            display: grid;
+            background-color: #fff;
+
+            pre {
+                border-radius: 0px 10px 10px 0px;
+            }
+        }
     }
 
     // Inline code

--- a/docs/assets/scss/_code.scss
+++ b/docs/assets/scss/_code.scss
@@ -39,7 +39,7 @@
             background-color: #fff;
 
             pre {
-                border-radius: 0px 10px 10px 0px;
+                border-radius: 0px 0px 0px 0px;
             }
         }
     }


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [ ] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [ ] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description
This PR addresses the issue where **several code snippets on the 'Getting Started' page** overflow their containers, causing them to extend beyond the main content area and overlap with the sidebar. The fix involves adjusting the CSS styling for code blocks. This ensures that all affected code snippets on this page are properly contained.

**Screenshots:**
**Before:**

<img width="400" alt="getting-started-code-block-before" src="https://github.com/user-attachments/assets/8866d88b-f2be-456d-9b86-26138b8adb05" />

**After:**

<img width="400" alt="getting-started-code-block-after" src="https://github.com/user-attachments/assets/47f01388-d939-4a25-b8f0-1a5999e22c7f" />


## Issue reference
Fixes: #1488