### PR TITLE
Upgrade docs - remove warning about CRDs

### DIFF
--- a/docs/content/guides/operations/kubernetes/kubernetes-upgrade/index.md
+++ b/docs/content/guides/operations/kubernetes/kubernetes-upgrade/index.md
@@ -75,12 +75,6 @@ rad env list
 
 ## Important considerations
 
-### CRD updates
-
-> **Note:** Due to a [Helm limitation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), Custom Resource Definitions (CRDs) are only installed during the initial Radius installation and are not automatically updated during upgrades.
->
-> If a Radius upgrade includes CRD changes (typically in major version upgrades), you may need to manually update the CRDs. Check the release notes for specific instructions when CRD updates are required.
-
 ### Breaking changes
 
 While Radius supports in-place upgrades, breaking changes may still occur between major versions. Always review the [release notes](https://github.com/radius-project/radius/releases) before upgrading to understand any breaking changes or migration steps required.


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [X] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [X] Commands include options for Linux, MacOS, and Windows within codetabs
- [X] New file and folder names are globally unique
- [X] Page references use shortcodes instead of markdown or URL links
- [X] Images use HTML style and have alternative text
- [X] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This pull request updates the Kubernetes upgrade guide by removing the section about manual Custom Resource Definition (CRD) updates. The documentation no longer highlights the Helm limitation regarding CRD upgrades, as this may be confusing to users. Instead, if there are changes that are impacted by this Helm limitation in the future, we'll include specific instructions in the release notes to address it.

Documentation update:

* Removed the "CRD updates" section from `docs/content/guides/operations/kubernetes/kubernetes-upgrade/index.md`, eliminating the note about Helm's limitation and manual CRD update instructions.

## Issue reference

N/A
