### PR TITLE
Add alias for /getting-started

### DIFF
--- a/docs/content/quick-start/index.md
+++ b/docs/content/quick-start/index.md
@@ -5,6 +5,7 @@ linkTitle: "Quick Start"
 weight: 10
 description: "Perform a quick installation of Radius and deploy your first application"
 aliases:
+    - /getting-started/
     - /getting-started/tutorial/
     - /getting-started/install/
     - /getting-started/first-app/


### PR DESCRIPTION
Add alias for quick start documentation
rad install outputs:

To get started with Radius, please visit https://docs.radapp.io/getting-started/

This fixes the alias for the new quick start.