### PR TITLE
update azure workload id setup script to include federated credential for dynamic-rp

### DIFF
--- a/docs/content/guides/operations/providers/azure-provider/howto-azure-provider-wi/snippets/install-radius-azwi.sh
+++ b/docs/content/guides/operations/providers/azure-provider/howto-azure-provider-wi/snippets/install-radius-azwi.sh
@@ -58,6 +58,20 @@ cat <<EOF > params-ucp.json
 EOF
 az ad app federated-credential create --id "${APPLICATION_OBJECT_ID}" --parameters @params-ucp.json
 
+# Create the dynamic-rp federated credential for the application
+cat <<EOF > params-dynamic-rp.json
+{
+  "name": "radius-dynamic-rp",
+  "issuer": "${SERVICE_ACCOUNT_ISSUER}",
+  "subject": "system:serviceaccount:radius-system:dynamic-rp",
+  "description": "Kubernetes service account federated credential for dynamic-rp",
+  "audiences": [
+    "api://AzureADTokenExchange"
+  ]
+}
+EOF
+az ad app federated-credential create --id "${APPLICATION_OBJECT_ID}" --parameters @params-dynamic-rp.json
+
 # Set the permissions for the application
 az ad sp create --id ${APPLICATION_CLIENT_ID}
 az role assignment create --assignee "${APPLICATION_CLIENT_ID}" --role "Owner" --scope "/subscriptions/${AZURE_SUBSCRIPTION_ID}/resourceGroups/${AZURE_RESOURCE_GROUP}"


### PR DESCRIPTION
This pull request adds support for creating a federated credential for the `dynamic-rp` Kubernetes service account in the Azure provider setup script. This improves integration with Azure AD by enabling token exchange for the `dynamic-rp` service account.

Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Added support for creating a federated credential for the `dynamic-rp` Kubernetes service account in the Azure provider setup script.

The script is reference in the Workload ID docs page: https://docs.radapp.io/guides/operations/providers/azure-provider/howto-azure-provider-wi/#setup-the-azure-workload-identity-for-radius

## Issue reference
N/A
<!--
Please reference the docs or Radius issue that this pull request addresses:

Fixes: #[issue number]
or
Fixes: https://github.com/radius-project/radius/issues/[issue number]
-->
