### PR TITLE
ci(dependabot): specify target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
+    target-branch: edge
     directory: /
     schedule:
       interval: weekly


### PR DESCRIPTION
This pull request makes a minor configuration update to the Dependabot settings for GitHub Actions. The change sets the target branch for updates to `edge` instead of the default branch.

* Dependabot will now create pull requests against the `edge` branch for GitHub Actions updates in `.github/dependabot.yml`.