### PR TITLE
fix: temp off persist-credentials in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
           ref: edge
           path: docs
-          persist-credentials: false
+          # persist-credentials: false
 
       - name: Configure git
         run: |


### PR DESCRIPTION
Comment out the persist-credentials option in release workflow.
