### PR TITLE
feat: add WinGet installation instructions for Radius CLI

### DIFF
--- a/docs/shared-content/installation/rad-cli/install-rad-cli.md
+++ b/docs/shared-content/installation/rad-cli/install-rad-cli.md
@@ -1,6 +1,6 @@
 Install the Radius CLI on your workstation with the appropriate installation script:
 
-{{< tabs "Linux/WSL" MacOS "Windows PowerShell" "GitHub Codespaces" "Azure Cloud Shell" Binaries >}}
+{{< tabs "Linux/WSL" MacOS "Windows PowerShell" "Windows WinGet" "GitHub Codespaces" "Azure Cloud Shell" Binaries >}}
 
 {{% codetab %}}
 {{< latest >}}
@@ -60,6 +60,20 @@ To install the latest edge release, first install [ORAS](https://oras.land/docs/
 $script=iwr -useb "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.ps1"; $block=[ScriptBlock]::Create($script); invoke-command -ScriptBlock $block -ArgumentList edge
 ```
 
+{{< /edge >}}
+{{% /codetab %}}
+
+{{% codetab %}}
+{{< latest >}}
+Run the following in a console window:
+
+```shell
+winget install --exact --id Radius.Radius
+```
+
+{{< /latest >}}
+{{< edge >}}
+Edge version installation via WinGet is not supported. To install the latest edge release, use the install script in the Windows PowerShell tab.
 {{< /edge >}}
 {{% /codetab %}}
 


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

This pull request updates the Radius CLI installation documentation to include instructions for installing via WinGet on Windows. The changes make it easier for Windows users to install the CLI using a native package manager.

fixes: https://github.com/radius-project/radius/issues/11012