### PR TITLE
Add group option to environment show command

### DIFF
--- a/docs/content/tutorials/create-environment/index.md
+++ b/docs/content/tutorials/create-environment/index.md
@@ -49,7 +49,7 @@ Successfully created environment "my-env" in resource group "my-group"
 Inspect the Environment using the `rad environment show`
 
 ```bash
-rad environment show my-env --output json
+rad environment show my-env --group my-group --output json
 ```
 
 You should see output similar to: 


### PR DESCRIPTION
Modified the command to include the group option for better environment inspection.

Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [x] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [x] Page references use shortcodes instead of markdown or URL links
- [x] Images use HTML style and have alternative text
- [x] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

The "rad environment show my-env --output json" command fails when the environment is in a non-default resource group.

 Added the "--group my-group" flag to fix this which is the group in the tutorial.

## Issue reference

Not an existing issue, found it during trying out the tutorial.
