### PR TITLE
Dev Container lock file and Dependabot configuration for devcontainers

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.3",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1",
+      "integrity": "sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1"
+    },
+    "ghcr.io/devcontainers/features/hugo:1": {
+      "version": "1.1.3",
+      "resolved": "ghcr.io/devcontainers/features/hugo@sha256:15465c956810aa164c9644b6df5ca36f6cac3e7a86b7dcc474a1fb830b21c509",
+      "integrity": "sha256:15465c956810aa164c9644b6df5ca36f6cac3e7a86b7dcc474a1fb830b21c509"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,21 +1,21 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/git:1": {
+    "ghcr.io/devcontainers/features/git:1.3.5": {
       "version": "1.3.5",
       "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
       "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
-    "ghcr.io/devcontainers/features/go:1": {
+    "ghcr.io/devcontainers/features/go:1.3.3": {
       "version": "1.3.3",
       "resolved": "ghcr.io/devcontainers/features/go@sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1",
       "integrity": "sha256:f5ef402a387201cf1ace38ea16c176612d61107c0fcd58da1bb84493cd93f6a1"
     },
-    "ghcr.io/devcontainers/features/hugo:1": {
+    "ghcr.io/devcontainers/features/hugo:1.1.3": {
       "version": "1.1.3",
       "resolved": "ghcr.io/devcontainers/features/hugo@sha256:15465c956810aa164c9644b6df5ca36f6cac3e7a86b7dcc474a1fb830b21c509",
       "integrity": "sha256:15465c956810aa164c9644b6df5ca36f6cac3e7a86b7dcc474a1fb830b21c509"
     },
-    "ghcr.io/devcontainers/features/node:1": {
+    "ghcr.io/devcontainers/features/node:1.7.1": {
       "version": "1.7.1",
       "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
       "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,13 +2,13 @@
 	"name": "Radius Docs Dev Container",
 	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
 	"features": {
-		"ghcr.io/devcontainers/features/git:1": {},
-		"ghcr.io/devcontainers/features/go:1": {},
-		"ghcr.io/devcontainers/features/hugo:1": {
+		"ghcr.io/devcontainers/features/git:1.3.5": {},
+		"ghcr.io/devcontainers/features/go:1.3.3": {},
+		"ghcr.io/devcontainers/features/hugo:1.1.3": {
 			"version": "0.117.0",
 			"extended": true
 		},
-		"ghcr.io/devcontainers/features/node:1": {}
+		"ghcr.io/devcontainers/features/node:1.7.1": {}
 	},
 	"remoteUser": "vscode",
 	"settings": {

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,9 @@ updates:
       all:
         patterns:
           - "*"
+
+  - package-ecosystem: devcontainers
+    target-branch: edge
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Thank you for helping make the Radius documentation better!

**Please follow this checklist before submitting:**

- [x] [Read the contribution guide](https://docs.radapp.io/community/contributing/docs/)
- [ ] Commands include options for Linux, MacOS, and Windows within codetabs
- [x] New file and folder names are globally unique
- [ ] Page references use shortcodes instead of markdown or URL links
- [ ] Images use HTML style and have alternative text
- [ ] Places where multiple code/command options are given have codetabs

In addition, please fill out the following to help reviewers understand this pull request:

## Description

Addition of a devcontainer lock file (`.devcontainer/devcontainer-lock.json`) to pin devcontainer feature versions with integrity hashes, and a new Dependabot configuration entry in `.github/dependabot.yml` for automated weekly updates of devcontainer features on the `edge` branch.

### Changes

- **`.devcontainer/devcontainer-lock.json`** (new): Pins devcontainer features (`git`, `go`, `hugo`, `node`) to specific versions with SHA-256 integrity hashes for reproducible builds.
- **`.github/dependabot.yml`** (modified): Adds a `devcontainers` package ecosystem entry targeting the `edge` branch with a weekly update schedule.

## Issue reference

N/A — Proactive improvement to pin devcontainer feature versions and enable automated dependency updates.