### PR TITLE
Update Radius.Core/recipePacks reference for kind/source

### DIFF
--- a/.cspellignore
+++ b/.cspellignore
@@ -851,8 +851,6 @@ RecipeConfigProperties
 RecipeConfigPropertiesEnvSecrets
 RecipeDefinition
 RecipeDefinitionParameters
-recipeKind
-recipeLocation
 RecipePackProperties
 RecipePackPropertiesRecipes
 recipePacks

--- a/docs/content/reference/resources/radius/radius.core/2025-08-01-preview/recipepacks/index.md
+++ b/docs/content/reference/resources/radius/radius.core/2025-08-01-preview/recipepacks/index.md
@@ -50,10 +50,10 @@ description: "Detailed reference documentation for radius.core/recipepacks@2025-
 
 | Property | Type | Description |
 |----------|------|-------------|
+| **kind** | 'bicep' | 'terraform' | The type of recipe (e.g., Terraform, Bicep) <br />_(Required)_ |
 | **parameters** | [RecipeDefinitionParameters](#recipedefinitionparameters) | Parameters to pass to the recipe |
-| **plainHttp** | bool | Connect to the location using HTTP (not HTTPS). This should be used when the location is known not to support HTTPS, for example in a locally hosted registry for Bicep recipes. Defaults to false (use HTTPS/TLS) |
-| **recipeKind** | 'bicep' | 'terraform' | The type of recipe <br />_(Required)_ |
-| **recipeLocation** | string | URL path to the recipe <br />_(Required)_ |
+| **plainHttp** | bool | Connect to the source using HTTP (not HTTPS). This should be used when the source is known not to support HTTPS, for example in a locally hosted registry for Bicep recipes. Defaults to false (use HTTPS/TLS) |
+| **source** | string | The source of the recipe. For Bicep recipes this is the OCI registry reference. For Terraform recipes this is the module source. <br />_(Required)_ |
 
 ### RecipeDefinitionParameters
 


### PR DESCRIPTION
## Description

Updates the `Radius.Core/recipePacks@2025-08-01-preview` reference to match the renamed schema:

- `RecipeDefinition.recipeKind` → `kind`, `recipeLocation` → `source` (radius-project/radius#11879).
- Refreshes the `plainHttp`/`source` descriptions to match the updated Bicep type `@doc` strings.
- Spell dictionary (`.cspellignore`): removes the now-unused `recipeKind`/`recipeLocation` entries. Verified with `cspell lint`.

Companion to radius-project/radius#12104. The reference table mirrors the regenerated Bicep types for the preview API.

> [!NOTE]
> Breaking change for the preview API: existing recipe packs must use `kind`/`source` going forward.