### PR TITLE
feat(workflows): update release and upmerge to use GitHub App for auth

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,29 +13,49 @@ on:
 
 permissions: {}
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
-  GITHUB_EMAIL: radiuscoreteam@service.microsoft.com
-  GITHUB_USER: Radius CI Bot
-
 jobs:
   release-docs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      contents: read
+      contents: read # required by actions/create-github-app-token
     steps:
+      # Generate a short-lived installation token scoped to this repository.
+      # Requires RADIUS_RELEASE_BOT installed on radius-project/docs with:
+      #   Contents: Read & Write, Administration: Read & Write
+      - name: Get App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RADIUS_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RADIUS_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-administration: write
+          repositories: docs
+
+      # Resolve the bot's GitHub-formatted name and email dynamically from the app slug
+      # so commits are attributed to the bot identity rather than hardcoded values.
+      - name: Get bot details
+        id: bot-details
+        uses: raven-actions/bot-details@ee8966a9ff6e7e42cbfc4a56b4ddb60a9d1b40a6 # v1.2.0
+        with:
+          bot-slug-name: ${{ steps.app-token.outputs.app-slug }}
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           ref: edge
           path: docs
           persist-credentials: true
 
       - name: Configure git
         run: |
-          git config --global user.email "${GITHUB_EMAIL}"
-          git config --global user.name "${GITHUB_USER}"
+          git config --global user.name "${GIT_USER_NAME}"
+          git config --global user.email "${GIT_USER_EMAIL}"
+        env:
+          GIT_USER_NAME: ${{ steps.bot-details.outputs.name }}
+          GIT_USER_EMAIL: ${{ steps.bot-details.outputs.email }}
 
       - name: Ensure inputs.version is valid semver
         run: |
@@ -57,8 +77,11 @@ jobs:
           ./docs/.github/scripts/release-docs.sh "${INPUT_VERSION}"
         env:
           INPUT_VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Change the default branch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api \
           --method PATCH \

--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -37,24 +37,48 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read # required by actions/create-github-app-token
     steps:
+      # Generate a short-lived installation token scoped to this repository.
+      # Requires RADIUS_RELEASE_BOT installed on radius-project/docs with:
+      #   Contents: Read & Write, Pull requests: Read & Write
+      - name: Get App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RADIUS_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RADIUS_RELEASE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+          permission-pull-requests: write
+          repositories: docs
+
+      # Resolve the bot's GitHub-formatted name and email dynamically from the app slug
+      # so commits are attributed to the bot identity rather than hardcoded values.
+      - name: Get bot details
+        id: bot-details
+        uses: raven-actions/bot-details@ee8966a9ff6e7e42cbfc4a56b4ddb60a9d1b40a6 # v1.2.0
+        with:
+          bot-slug-name: ${{ steps.app-token.outputs.app-slug }}
+
       # Checkout the edge branch
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: edge
+          token: ${{ steps.app-token.outputs.token }}
           # https://github.com/actions/checkout/issues/125#issuecomment-570254411
           fetch-depth: 0
           persist-credentials: true
 
       - name: Configure git
-        env:
-          GH_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
         run: |
-          git config --global user.email "radiuscoreteam@service.microsoft.com"
-          git config --global user.name "Radius CI Bot"
-          git remote set-url origin "https://${GH_TOKEN}@github.com/${{ github.repository }}"
+          git config --global user.name "${GIT_USER_NAME}"
+          git config --global user.email "${GIT_USER_EMAIL}"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}"
+        env:
+          GIT_USER_NAME: ${{ steps.bot-details.outputs.name }}
+          GIT_USER_EMAIL: ${{ steps.bot-details.outputs.email }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       # Create a new branch from edge. This branch will be used to PR back into edge.
       - name: Create new branch
@@ -89,6 +113,6 @@ jobs:
       - name: Create pull request
         if: env.NO_CHANGES != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr create --title "Upmerge to edge" --body "Upmerge to edge (kicked off by @${{ github.triggering_actor }})" --base edge --head "${BRANCH_NAME}"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for release and upmerge automation to use a GitHub App token for authentication, replacing the previous use of a personal access token (PAT). It also dynamically resolves the bot's name and email, ensuring that commits are properly attributed to the bot identity rather than hardcoded values. These changes improve security and maintainability by leveraging GitHub Apps and reducing reliance on static secrets.