### PR TITLE
Add Dependabot cooldown to all updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: ci
       include: scope
@@ -25,6 +27,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       all:
         patterns: ["*"]
@@ -34,6 +38,8 @@ updates:
     directory: /docs
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: deps
       include: scope
@@ -46,6 +52,8 @@ updates:
     directory: /docs
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: deps
       include: scope


### PR DESCRIPTION
## Description

Adds a `cooldown` block (`default-days: 7`) to every active `updates:` entry in `.github/dependabot.yml`. The cooldown delays Dependabot update PRs until 7 days after a dependency release, reducing PR churn from rapid back-to-back releases.

This change is scoped to this repo and is part of an org-wide rollout following [radius-project/radius #12141](https://github.com/radius-project/radius/pull/12141) ("Add Dependabot cooldown to all updates entries").

This is a maintenance change with **no functional impact** on the docs site — it only affects Dependabot's update scheduling behavior. All four active entries (`github-actions`, `devcontainers`, `gomod`, `npm`) now carry the cooldown; commented-out entries were left untouched. The file remains valid YAML and schema-valid (Dependabot v2 / schemastore 2.0).

> Note: This PR targets the `edge` base branch rather than the release default branch.

## Issue reference

N/A — maintenance / no-functional-change task, part of the org-wide Dependabot cooldown rollout (follows radius-project/radius #12141).