### PR TITLE
fix(nav): hide shared-content installation section from sidebar

### DIFF
--- a/docs/content/tutorials/deploy-application/index.md
+++ b/docs/content/tutorials/deploy-application/index.md
@@ -16,9 +16,7 @@ Add the following to `app.bicep`:
 
 {{% rad file="snippets/app.bicep" embed=true marker="//IMPORT" %}}
 
-The `extension radius` statement imports the resource types built into Radius. 
-
-The `extension radiusResources` statement imports the PostgreSQL resource type created in the previous step.
+The `extension radius` statement imports the resource types built into Radius.
 
 {{% rad file="snippets/app.bicep" embed=true marker="//PARAM" %}}
 

--- a/docs/content/tutorials/deploy-application/snippets/app.bicep
+++ b/docs/content/tutorials/deploy-application/snippets/app.bicep
@@ -1,6 +1,5 @@
 //IMPORT
 extension radius
-extension radiusResources
 //IMPORT
 
 //PARAM

--- a/docs/shared-content/installation/_index.md
+++ b/docs/shared-content/installation/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Installation shared content"
+build:
+  list: never
+  render: never
+  publishResources: false
+cascade:
+  build:
+    list: never
+    render: never
+    publishResources: false
+---
+
+<!-- Include-only snippets used via {{< read >}}; hidden from nav/rendering. -->


### PR DESCRIPTION
## Description

The `shared-content/` directory is mounted into Hugo's `content` (see `config.toml`), which caused the include-only snippets in `shared-content/installation/` to be rendered as pages and surfaced as an **"Installations"** section in the sidebar navigation.

## Change

Added `shared-content/installation/_index.md` with `_build: { list: never, render: never }` plus a `cascade` so the section and all its descendants are excluded from rendering and the nav.

Because the `read` shortcode reads files directly from disk (`readFile`), all existing `{{< read >}}` includes continue to work.

## Verification

- Ran `hugo server` locally: the "Installations" nav item no longer appears.
- Confirmed pages using `{{< read >}}` from `shared-content/installation/` (e.g. *Install rad CLI*) still render their included content.