### PR TITLE
Add Roadmap link to top navigation

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -69,6 +69,11 @@ name = "Discord"
 weight = 90
 url = "https://aka.ms/Radius/Discord"
 pre = "<i class='fab fa-discord'></i>"
+[[menu.main]]
+name = "Roadmap"
+weight = 100
+url = "https://aka.ms/radius-roadmap"
+pre = "<i class='fas fa-map-signs'></i>"
 
 [params]
 copyright = "The Radius Authors. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see the https://linuxfoundation.org/trademark-usage/ page."


### PR DESCRIPTION
## Description

Removes the "Releases" version-selector dropdown from the top navigation and replaces it with a **Roadmap** link pointing to https://aka.ms/radius-roadmap.

The top nav is now ordered: **Home · Blog · GitHub · Roadmap · Discord**.

## Changes
- Removed `version_menu` and `params.versions` entries from `config.toml`
- Added a `Roadmap` entry to `[[menu.main]]` (weight 50)

## Type of change
This pull request is a minor documentation navigation change.